### PR TITLE
Remove unused upsert_track import

### DIFF
--- a/songsearch/core/metadata_enricher.py
+++ b/songsearch/core/metadata_enricher.py
@@ -8,7 +8,7 @@ import acoustid
 import musicbrainzngs
 from mutagen import File as MutagenFile
 
-from .db import upsert_track, update_fields
+from .db import update_fields
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- remove unused `upsert_track` from metadata_enricher imports

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c817305964832cb638050f927387ba