### PR TITLE
Add helper to look up tracks by path

### DIFF
--- a/songsearch/core/db.py
+++ b/songsearch/core/db.py
@@ -126,6 +126,11 @@ def update_fields(con: sqlite3.Connection, path: str, updates: Dict[str, Any]):
             con.execute("INSERT INTO tracks_fts (title,artist,album,genre,path) VALUES (?,?,?,?,?)",
                         (r["title"], r["artist"], r["album"], r["genre"], r["path"]))
 
+def get_by_path(con: sqlite3.Connection, path: str) -> sqlite3.Row | None:
+    """Return the track row for *path* or ``None`` if it doesn't exist."""
+
+    return con.execute("SELECT * FROM tracks WHERE path=?", (path,)).fetchone()
+
 def query_tracks(con: sqlite3.Connection, where: str = "", params: Iterable[Any] = ()) -> Iterable[sqlite3.Row]:
     sql = "SELECT * FROM tracks"
     if where:

--- a/songsearch/ui/main_window.py
+++ b/songsearch/ui/main_window.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt, QThread, Signal, QSize
 from PySide6.QtGui import QIcon, QPixmap
 from pathlib import Path
-from ..core.db import connect, init_db, query_tracks
+from ..core.db import connect, get_by_path, init_db, query_tracks
 from ..core.scanner import scan_path
 from ..core.cover_art import ensure_cover_for_path
 import logging
@@ -180,7 +180,7 @@ class MainWindow(QMainWindow):
         row_idx = self._find_row_index_by_path(path)
         if row_idx is None:
             return
-        row_data = self.con.execute("SELECT * FROM tracks WHERE path=?", (path,)).fetchone()
+        row_data = get_by_path(self.con, path)
         if not row_data:
             return
         self._set_row_from_data(row_idx, row_data)


### PR DESCRIPTION
## Summary
- add a database helper to retrieve track rows by their path
- use the new helper from the main window when refreshing covers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8414d54e0832cbbaae3c19468c3bc