### PR TITLE
Refactor scanner to reuse mutagen metadata

### DIFF
--- a/songsearch/core/scanner.py
+++ b/songsearch/core/scanner.py
@@ -8,6 +8,17 @@ from .utils import is_audio
 logger = logging.getLogger(__name__)
 
 
+TAG_KEY_ALIASES = {
+    "title": ("title", "TITLE", "TIT2", "\u00a9nam"),
+    "artist": ("artist", "ARTIST", "TPE1", "\u00a9ART"),
+    "album": ("album", "ALBUM", "TALB", "\u00a9alb"),
+    "genre": ("genre", "GENRE", "TCON", "\u00a9gen"),
+    "date": ("date", "DATE", "TDRC", "TDOR", "TORY", "\u00a9day"),
+    "year": ("year", "YEAR", "TYER"),
+    "tracknumber": ("tracknumber", "TRACKNUMBER", "TRCK", "trkn"),
+}
+
+
 def scan_path(con, root: Path):
     root = root.expanduser().resolve()
     for p in root.rglob("*"):
@@ -21,36 +32,89 @@ def scan_path(con, root: Path):
                 "file_size": stat.st_size,
                 "missing": 0
             }
-            audio = MutagenFile(str(p), easy=True)
+            audio = MutagenFile(str(p))
             if audio:
-                info["title"] = _first(audio, "title")
-                info["artist"] = _first(audio, "artist")
-                info["album"] = _first(audio, "album")
-                info["genre"] = _first(audio, "genre")
-                info["year"] = _int_or_none(_first(audio, "date") or _first(audio, "year"))
-                info["track_no"] = _int_or_none(_first(audio, "tracknumber"))
+                tags = getattr(audio, "tags", None)
+                if tags:
+                    info["title"] = _first(tags, TAG_KEY_ALIASES["title"])
+                    info["artist"] = _first(tags, TAG_KEY_ALIASES["artist"])
+                    info["album"] = _first(tags, TAG_KEY_ALIASES["album"])
+                    info["genre"] = _first(tags, TAG_KEY_ALIASES["genre"])
+                    info["year"] = _int_or_none(
+                        _first(tags, TAG_KEY_ALIASES["date"]) or _first(tags, TAG_KEY_ALIASES["year"])
+                    )
+                    info["track_no"] = _int_or_none(_first(tags, TAG_KEY_ALIASES["tracknumber"]))
                 info["format"] = p.suffix.lower().lstrip(".")
-            audio_full = MutagenFile(str(p))
-            if audio_full and getattr(audio_full.info, "length", None):
-                info["duration"] = float(audio_full.info.length)
-            if audio_full and getattr(audio_full.info, "bitrate", None):
-                info["bitrate"] = int(audio_full.info.bitrate)
-            if audio_full and getattr(audio_full.info, "sample_rate", None):
-                info["samplerate"] = int(audio_full.info.sample_rate)
-            if audio_full and getattr(audio_full.info, "channels", None):
-                info["channels"] = int(audio_full.info.channels)
+                audio_info = getattr(audio, "info", None)
+                if audio_info and getattr(audio_info, "length", None) is not None:
+                    info["duration"] = float(audio_info.length)
+                if audio_info and getattr(audio_info, "bitrate", None) is not None:
+                    info["bitrate"] = int(audio_info.bitrate)
+                if audio_info and getattr(audio_info, "sample_rate", None) is not None:
+                    info["samplerate"] = int(audio_info.sample_rate)
+                if audio_info and getattr(audio_info, "channels", None) is not None:
+                    info["channels"] = int(audio_info.channels)
             upsert_track(con, info)
         except Exception as e:
             logger.warning("[scan] error with %s: %s", p, e)
 
 
-def _first(meta, key: str):
-    v = meta.get(key)
-    if v is None:
+def _first(meta, key):
+    if meta is None or key is None:
         return None
-    if isinstance(v, (list, tuple)):
-        return v[0] if v else None
-    return v
+
+    if isinstance(key, (list, tuple)):
+        for name in key:
+            value = _first(meta, name)
+            if value not in (None, ""):
+                return value
+        return None
+
+    candidates = []
+    getter = getattr(meta, "getall", None)
+    if callable(getter):
+        try:
+            candidates.extend(getter(key) or [])
+        except Exception:
+            pass
+
+    getter = getattr(meta, "get", None)
+    if callable(getter):
+        candidates.append(getter(key))
+    else:
+        try:
+            candidates.append(meta[key])
+        except Exception:
+            pass
+
+    for candidate in candidates:
+        value = _coerce_first(candidate)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _coerce_first(value):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.decode("latin-1", errors="ignore")
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            normalized = _coerce_first(item)
+            if normalized not in (None, ""):
+                return normalized
+        return None
+    if hasattr(value, "text"):
+        return _coerce_first(value.text)
+    if hasattr(value, "value"):
+        return _coerce_first(value.value)
+    return str(value)
 
 
 def _int_or_none(s):


### PR DESCRIPTION
## Summary
- update `scan_path` to build both tag and technical metadata from a single Mutagen parse
- add tag key aliases and value coercion helpers to normalize metadata across formats

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c855a65f28832cac82010cfebca4db