### PR TITLE
Add beginner launch guide and update MIT year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 SongSearch Organizer
+Copyright (c) 2025 SongSearch Organizer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -156,6 +156,25 @@ reglas:
 
 ---
 
+## 🧑‍🏫 Lanzamiento de la app para principiantes
+
+¿Nunca has lanzado una app de Python? Sigue estos pasos sencillos:
+
+1. **Instala Python 3.13** desde [python.org](https://www.python.org/downloads/) y, durante la instalación en Windows, marca "Add Python to PATH".
+2. **Descarga el proyecto**: `git clone https://github.com/tu-usuario/SongSearch-Organizer.git` o baja el ZIP y descomprímelo.
+3. **Abre una terminal** (Terminal en macOS/Linux o PowerShell en Windows) y ve a la carpeta del proyecto: `cd SongSearch-Organizer`.
+4. **Crea un entorno aislado**: `python -m venv .venv`.
+5. **Activa el entorno**:
+   - macOS/Linux: `source .venv/bin/activate`
+   - Windows: `.venv\Scripts\activate`
+6. **Instala la app** dentro del entorno: `pip install .` (o `pip install -r requirements.lock` si quieres replicar el entorno del CI).
+7. **Lanza la interfaz gráfica**: `python -m songsearch.app`.
+8. **En los próximos usos**, solo repite los pasos 3, 5 y 7 para abrir la app de nuevo.
+
+> Consejos rápidos: Si prefieres la interfaz de línea de comandos, ejecuta `python -m songsearch.cli --help`. Para salir del entorno virtual, usa `deactivate`.
+
+---
+
 ## 🚀 Uso (desarrollo)
 
 1. **Escanear** carpeta y poblar DB:
@@ -267,4 +286,4 @@ fpcalc -version
 
 ## 📜 Licencia
 
-Este proyecto se distribuye bajo la licencia [MIT](LICENSE).
+Este proyecto se distribuye bajo la licencia [MIT (2025)](LICENSE).


### PR DESCRIPTION
## Summary
- add a beginner-friendly launch guide to the README with step-by-step setup instructions
- update license references to MIT (2025) to reflect the new year

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c86b74c020832c8ec65afe5f4bddcc