### PR TITLE
Fix table selection behavior setup

### DIFF
--- a/songsearch/ui/main_window.py
+++ b/songsearch/ui/main_window.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from PySide6.QtCore import QSize, Qt, QThread, Signal
 from PySide6.QtGui import QIcon, QPixmap
 from PySide6.QtWidgets import (
+    QAbstractItemView,
     QFileDialog,
     QHBoxLayout,
     QLabel,
@@ -80,8 +81,8 @@ class MainWindow(QMainWindow):
             ["Título", "Artista", "Álbum", "Género", "Año", "Ruta"]
         )
         self.table.setSortingEnabled(True)
-        self.table.setSelectionBehavior(self.table.SelectRows)
-        self.table.setEditTriggers(self.table.NoEditTriggers)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.table.setIconSize(QSize(ICON_SIZE, ICON_SIZE))
         self.table.verticalHeader().setDefaultSectionSize(ICON_SIZE + 12)
 


### PR DESCRIPTION
## Summary
- import QAbstractItemView for the main window table setup
- configure the table selection behavior and edit triggers using the scoped enums

## Testing
- QT_QPA_PLATFORM=offscreen python -m songsearch.app *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c86f023834832c82c503014294618f