### PR TITLE
Gracefully stop scan thread on shutdown

### DIFF
--- a/songsearch/core/scanner.py
+++ b/songsearch/core/scanner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 
 from mutagen import File as MutagenFile
@@ -22,9 +23,16 @@ TAG_KEY_ALIASES = {
 }
 
 
-def scan_path(con, root: Path):
+def scan_path(
+    con,
+    root: Path,
+    should_interrupt: Callable[[], bool] | None = None,
+):
     root = root.expanduser().resolve()
     for p in root.rglob("*"):
+        if should_interrupt is not None and should_interrupt():
+            logger.info("[scan] interrupted while visiting %s", p)
+            break
         if not p.is_file() or not is_audio(p):
             continue
         try:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,6 +36,23 @@ def test_scan_and_simulate(tmp_path: Path) -> None:
     assert len(plan) == 1
 
 
+def test_scan_interrupts(tmp_path: Path) -> None:
+    db_path = init_db(tmp_path)
+    con = connect(db_path)
+    for idx in range(3):
+        _create_wav(tmp_path / f"track-{idx}.wav")
+
+    calls = {"count": 0}
+
+    def _should_stop() -> bool:
+        calls["count"] += 1
+        return True
+
+    scan_path(con, tmp_path, should_interrupt=_should_stop)
+    assert calls["count"] >= 1
+    assert query_tracks(con) == []
+
+
 def test_query_tracks_full_text(tmp_path: Path) -> None:
     db_path = init_db(tmp_path)
     con = connect(db_path)


### PR DESCRIPTION
## Summary
- allow `scan_path` to accept an optional interrupt callback so long scans can stop early
- make the GUI scan thread honour interruption requests and block on close to avoid crashes
- add a regression test covering the early-exit behaviour of the scanner

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68c87081168c832c830d0f62ffa0813b