### PR TITLE
Ensure pytest can import songsearch package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,4 @@ output = "coverage.xml"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-ra"
+pythonpath = ["."]


### PR DESCRIPTION
## Summary
- add the repository root to pytest's configured pythonpath so the songsearch package can always be imported when using the pytest entry point

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c87284a074832cbef5362d9731eb68