### PR TITLE
Fix ruff lint violations

### DIFF
--- a/songsearch/core/cover_art.py
+++ b/songsearch/core/cover_art.py
@@ -162,7 +162,7 @@ def _cleanup_partial(path: Path) -> None:
 
 
 def _is_timeout_error(error: object) -> bool:
-    if isinstance(error, (TimeoutError, socket.timeout)):
+    if isinstance(error, TimeoutError | socket.timeout):
         return True
     try:
         message = str(error)

--- a/songsearch/core/scanner.py
+++ b/songsearch/core/scanner.py
@@ -82,7 +82,7 @@ def _first(meta, key):
     if meta is None or key is None:
         return None
 
-    if isinstance(key, (list, tuple)):
+    if isinstance(key, list | tuple):
         for name in key:
             value = _first(meta, name)
             if value not in (None, ""):
@@ -123,7 +123,7 @@ def _coerce_first(value):
             return value.decode("utf-8")
         except UnicodeDecodeError:
             return value.decode("latin-1", errors="ignore")
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, list | tuple):
         for item in value:
             normalized = _coerce_first(item)
             if normalized not in (None, ""):

--- a/songsearch/ui/main_window.py
+++ b/songsearch/ui/main_window.py
@@ -260,7 +260,7 @@ class MainWindow(QMainWindow):
         self.refresh()
         logger.info("scan completed")
 
-    def closeEvent(self, event: QCloseEvent) -> None:  # pragma: no cover - GUI specific
+    def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802  # pragma: no cover - GUI specific
         thread = self._scan_thread
         if thread is not None and thread.isRunning():
             thread.requestInterruption()


### PR DESCRIPTION
## Summary
- silence the closeEvent Qt override by adding a ruff N802 inline ignore
- update timeout detection helpers to use modern isinstance unions
- modernize scanner helpers to rely on PEP 604 union syntax

## Testing
- ruff check .
- ruff format --check .

------
https://chatgpt.com/codex/tasks/task_e_68c87cbfa454832ca31637bbef3aecbe