### PR TITLE
Fix PySide6 imports for selection classes

### DIFF
--- a/songsearch/ui/main_window.py
+++ b/songsearch/ui/main_window.py
@@ -7,13 +7,18 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
-from PySide6.QtCore import QAbstractTableModel, QModelIndex, Qt, QTimer
+from PySide6.QtCore import (
+    QAbstractTableModel,
+    QItemSelection,
+    QItemSelectionModel,
+    QModelIndex,
+    Qt,
+    QTimer,
+)
 from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QHeaderView,
-    QItemSelection,
-    QItemSelectionModel,
     QLineEdit,
     QMainWindow,
     QMessageBox,


### PR DESCRIPTION
## Summary
- import QItemSelection and QItemSelectionModel from PySide6.QtCore where they are defined
- update the QtWidgets import list accordingly so the UI module imports remain valid

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c887230f6c832c88d9413fd657e3af