### PR TITLE
fix: restore menu access for redesigned UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Todas las novedades relevantes se documentan en este archivo siguiendo un formato inspirado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/).
 
+## [0.3.2] - 2025-09-30
+### Añadido
+- Interfaz principal rediseñada con cabecera estilo macOS, tarjeta de herramientas y distintivo dinámico de resultados.
+- Centro de ayuda contextual que muestra atajos clave y el estado actual de dependencias/API.
+- Panel de detalles con encabezado destacado y contenedor de acciones con botones tonales.
+
+### Cambiado
+- La barra de acciones pasa a ser una toolbar unificada con botones tipo píldora y atajos globales.
+- Las leyendas de biblioteca e inspector se actualizan automáticamente con cada selección y búsqueda.
+
+### Corregido
+- El botón «MusicBrainz» abre ahora la ficha correspondiente en el navegador predeterminado.
+
 ## [0.3.1] - 2025-09-15
 ### Añadido
 - Botonera superior con acciones de **Escanear**, **Enriquecer** y **Espectro**, incluyendo soporte para iconos opcionales en `assets/icons/`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SongSearch Organizer (v0.3.1)
+# SongSearch Organizer (v0.3.2)
 
 ![Coverage](assets/coverage-badge.svg)
 
@@ -29,7 +29,7 @@ La raíz del repositorio incluye `requirements.lock` generado con `pip-compile`.
 
 Consulta [CHANGELOG.md](CHANGELOG.md) para ver la lista completa de cambios entre versiones.
 
-## ✨ Características (MVP v0.3.1)
+## ✨ Características (MVP v0.3.2)
 
 - **Organizador por plantillas**:  
   `{Genero}/{Año}/{Artista}/{Álbum}/{TrackNo - Título}.{ext}` (personalizable).
@@ -104,7 +104,7 @@ Crea `.env` en la raíz con tus claves:
 
 ```ini
 ACOUSTID_API_KEY=tu_api_key_opcional
-MUSICBRAINZ_USER_AGENT=SongSearchOrganizer/0.3.1 (tu_email@ejemplo.com)
+MUSICBRAINZ_USER_AGENT=SongSearchOrganizer/0.3.2 (tu_email@ejemplo.com)
 SPEK_APP_PATH=
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "songsearch-organizer"
-version = "0.3.1"
+version = "0.3.2"
 description = "Organizador de bibliotecas musicales con UI PySide6 y CLI Typer."
 readme = "README.md"
 license = "MIT"

--- a/songsearch/__init__.py
+++ b/songsearch/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/songsearch/ui/details_panel.py
+++ b/songsearch/ui/details_panel.py
@@ -7,7 +7,8 @@ from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
 from typing import Any, cast
 
-from PySide6.QtCore import Qt, QThread, Signal
+from PySide6.QtCore import Qt, QThread, Signal, QUrl
+from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
     QFormLayout,
     QHBoxLayout,
@@ -16,6 +17,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QVBoxLayout,
     QWidget,
+    QFrame,
 )
 
 from ..core.db import connect, get_by_path
@@ -69,6 +71,8 @@ class DetailsPanel(QWidget):
         self._enrich_min_confidence = 0.6
         self._enrich_write_tags = False
 
+        self._title_label: QLabel | None = None
+        self._subtitle_label: QLabel | None = None
         self._value_labels: dict[str, QLabel] = {}
         self._can_enrich_metadata = True
         self._can_generate_spectrum = True
@@ -85,7 +89,22 @@ class DetailsPanel(QWidget):
     def _setup_ui(self) -> None:
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(20)
+        layout.setSpacing(24)
+
+        header_layout = QVBoxLayout()
+        header_layout.setContentsMargins(0, 0, 0, 0)
+        header_layout.setSpacing(4)
+
+        self._title_label = QLabel("Selecciona una pista")
+        self._title_label.setObjectName("DetailsHeadline")
+        header_layout.addWidget(self._title_label)
+
+        self._subtitle_label = QLabel("Los metadatos aparecerán aquí.")
+        self._subtitle_label.setObjectName("DetailsSubheadline")
+        self._subtitle_label.setWordWrap(True)
+        header_layout.addWidget(self._subtitle_label)
+
+        layout.addLayout(header_layout)
 
         form = QFormLayout()
         form.setLabelAlignment(Qt.AlignRight | Qt.AlignVCenter)
@@ -97,22 +116,27 @@ class DetailsPanel(QWidget):
 
         layout.addLayout(form)
 
-        layout.addSpacing(16)
-
-        actions = QHBoxLayout()
-        actions.setContentsMargins(0, 0, 0, 0)
+        actions_frame = QFrame(self)
+        actions_frame.setObjectName("DetailsActions")
+        ensure_styled_background(actions_frame)
+        actions = QHBoxLayout(actions_frame)
+        actions.setContentsMargins(16, 16, 16, 16)
         actions.setSpacing(12)
 
         self.btn_open = QPushButton("Abrir…")
+        self.btn_open.setProperty("secondaryButton", True)
         actions.addWidget(self.btn_open)
 
         self.btn_reveal = QPushButton("Mostrar en carpeta")
+        self.btn_reveal.setProperty("secondaryButton", True)
         actions.addWidget(self.btn_reveal)
 
         self.btn_copy_path = QPushButton("Copiar ruta")
+        self.btn_copy_path.setProperty("secondaryButton", True)
         actions.addWidget(self.btn_copy_path)
 
         self.btn_musicbrainz = QPushButton("MusicBrainz")
+        self.btn_musicbrainz.setProperty("tonalButton", True)
         actions.addWidget(self.btn_musicbrainz)
 
         self.btn_enrich = QPushButton("Enriquecer")
@@ -124,8 +148,18 @@ class DetailsPanel(QWidget):
         actions.addWidget(self.btn_spectrum)
 
         actions.addStretch(1)
-        layout.addLayout(actions)
+        layout.addWidget(actions_frame)
         layout.addStretch(1)
+
+        for button in (
+            self.btn_open,
+            self.btn_reveal,
+            self.btn_copy_path,
+            self.btn_musicbrainz,
+            self.btn_enrich,
+            self.btn_spectrum,
+        ):
+            button.setCursor(Qt.PointingHandCursor)
 
     def _build_detail_labels(self) -> Iterable[tuple[str, QLabel]]:
         """Return an iterable of ``(field, label_widget)`` pairs for the form."""
@@ -168,6 +202,12 @@ class DetailsPanel(QWidget):
         """
 
         self._current_data = None
+        if self._title_label is not None:
+            self._title_label.setText("Selecciona una pista")
+            self._title_label.setToolTip("")
+        if self._subtitle_label is not None:
+            self._subtitle_label.setText("Los metadatos aparecerán aquí.")
+            self._subtitle_label.setToolTip("")
         for label in self._value_labels.values():
             label.setText("—")
         for button in self._iter_action_buttons():
@@ -200,6 +240,7 @@ class DetailsPanel(QWidget):
             return
 
         self._current_data = normalized
+        self._update_headline(normalized)
         for field, label in self._value_labels.items():
             label.setText(self._format_field_value(field, normalized.get(field)))
 
@@ -266,6 +307,49 @@ class DetailsPanel(QWidget):
                 return str(value)
         return str(value)
 
+    def _update_headline(self, data: Mapping[str, Any]) -> None:
+        if self._title_label is None or self._subtitle_label is None:
+            return
+        title = self._derive_title(data)
+        subtitle = self._derive_subtitle(data)
+        self._title_label.setText(title)
+        self._title_label.setToolTip(title)
+        self._subtitle_label.setText(subtitle)
+        self._subtitle_label.setToolTip(subtitle)
+
+    def _derive_title(self, data: Mapping[str, Any]) -> str:
+        raw_title = data.get("title")
+        if isinstance(raw_title, str) and raw_title.strip():
+            return raw_title.strip()
+        path_value = data.get("path")
+        if isinstance(path_value, str) and path_value:
+            return Path(path_value).stem
+        return "Pista seleccionada"
+
+    def _derive_subtitle(self, data: Mapping[str, Any]) -> str:
+        artist = self._coerce_str(data.get("artist"))
+        album = self._coerce_str(data.get("album"))
+        year = self._coerce_str(data.get("year"))
+        parts: list[str] = []
+        if artist:
+            parts.append(artist)
+        if album and year:
+            parts.append(f"{album} ({year})")
+        elif album:
+            parts.append(album)
+        elif year:
+            parts.append(year)
+        if not parts:
+            return "Metadatos pendientes"
+        return " · ".join(parts)
+
+    def _coerce_str(self, value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value.strip()
+        return str(value)
+
     def _toggle_action_buttons(self, enabled: bool) -> None:
         for button in self._iter_action_buttons():
             self._apply_capability_to_button(button, enabled)
@@ -289,7 +373,10 @@ class DetailsPanel(QWidget):
             if self._can_enrich_metadata:
                 self.btn_enrich.setToolTip("")
             else:
-                hint = self._enrich_disabled_reason or "Configura las APIs para habilitar el enriquecimiento."
+                hint = (
+                    self._enrich_disabled_reason
+                    or "Configura las APIs para habilitar el enriquecimiento."
+                )
                 self.btn_enrich.setToolTip(hint)
         if hasattr(self, "btn_spectrum") and isinstance(self.btn_spectrum, QPushButton):
             if self._can_generate_spectrum:
@@ -324,8 +411,47 @@ class DetailsPanel(QWidget):
     # UI actions
     # ----------------------------------------------------------------------------------
     def _connect_action_signals(self) -> None:
+        self.btn_musicbrainz.clicked.connect(self._open_musicbrainz)
         self.btn_spectrum.clicked.connect(self._make_spectrum)
         self.btn_enrich.clicked.connect(self._enrich_one)
+
+    def _open_musicbrainz(self) -> None:
+        data = self._current_data or {}
+        if not data:
+            QMessageBox.information(
+                self,
+                "Sin metadatos",
+                "Selecciona una pista con coincidencias de MusicBrainz para abrir la ficha.",
+            )
+            return
+
+        release_id = self._coerce_str(data.get("mb_release_id"))
+        group_id = self._coerce_str(data.get("mb_release_group_id"))
+        recording_id = self._coerce_str(data.get("mb_recording_id"))
+
+        if release_id:
+            target_url = f"https://musicbrainz.org/release/{release_id}"
+            description = "el lanzamiento en MusicBrainz"
+        elif group_id:
+            target_url = f"https://musicbrainz.org/release-group/{group_id}"
+            description = "el grupo de lanzamientos en MusicBrainz"
+        elif recording_id:
+            target_url = f"https://musicbrainz.org/recording/{recording_id}"
+            description = "la grabación en MusicBrainz"
+        else:
+            QMessageBox.information(
+                self,
+                "Sin identificadores",
+                "Enriquece la pista para obtener enlaces directos a MusicBrainz.",
+            )
+            return
+
+        if not QDesktopServices.openUrl(QUrl(target_url)):
+            QMessageBox.warning(
+                self,
+                "No se pudo abrir MusicBrainz",
+                f"No fue posible abrir {description}. Copia el enlace manualmente:\n{target_url}",
+            )
 
     def _set_button_busy(
         self,

--- a/songsearch/ui/main_window.py
+++ b/songsearch/ui/main_window.py
@@ -7,7 +7,7 @@ import sqlite3
 import subprocess
 import sys
 import time
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +22,7 @@ from PySide6.QtCore import (
     QTimer,
     Signal,
 )
-from PySide6.QtGui import QAction, QCloseEvent, QColor, QGuiApplication, QIcon
+from PySide6.QtGui import QAction, QCloseEvent, QColor, QGuiApplication, QIcon, QKeySequence
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QDialog,
@@ -37,8 +37,10 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QMainWindow,
     QMenu,
+    QMenuBar,
     QMessageBox,
     QPushButton,
+    QShortcut,
     QSplitter,
     QStatusBar,
     QTableView,
@@ -333,8 +335,30 @@ class MainWindow(QMainWindow):
         self._btn_spectrum: QPushButton | None = None
         self._btn_config: QPushButton | None = None
         self._scan_worker: _ScanWorker | None = None
+        self._summary_badge: QLabel | None = None
+        self._help_button: QPushButton | None = None
+        self._table_caption: QLabel | None = None
+        self._inspector_caption: QLabel | None = None
+        self._shortcuts: list[QShortcut] = []
+        self._action_configure_api: QAction | None = None
+        self._action_scan: QAction | None = None
+        self._action_open_track: QAction | None = None
+        self._action_reveal_track: QAction | None = None
+        self._action_exit: QAction | None = None
+        self._action_copy_paths: QAction | None = None
+        self._action_focus_search: QAction | None = None
+        self._action_clear_search: QAction | None = None
+        self._action_select_all: QAction | None = None
+        self._action_refresh: QAction | None = None
+        self._action_enrich: QAction | None = None
+        self._action_spectrum: QAction | None = None
+        self._action_help_overview: QAction | None = None
+        self._action_about: QAction | None = None
 
         self._build_ui()
+        self._create_actions()
+        self._build_menus()
+        self._setup_shortcuts()
         self._refresh_dependency_state()
         self.refresh_results()
         QTimer.singleShot(0, self._handle_startup_prompts)
@@ -351,11 +375,11 @@ class MainWindow(QMainWindow):
 
     def _load_api_credentials(self) -> None:
         stored = dotenv_values(self._env_path) if self._env_path.exists() else {}
-        self._api_key = (os.getenv("ACOUSTID_API_KEY") or stored.get("ACOUSTID_API_KEY", "")).strip()
+        self._api_key = (
+            os.getenv("ACOUSTID_API_KEY") or stored.get("ACOUSTID_API_KEY", "")
+        ).strip()
         self._musicbrainz_ua = (
-            os.getenv("MUSICBRAINZ_USER_AGENT")
-            or stored.get("MUSICBRAINZ_USER_AGENT", "")
-            or ""
+            os.getenv("MUSICBRAINZ_USER_AGENT") or stored.get("MUSICBRAINZ_USER_AGENT", "") or ""
         ).strip()
 
     def _handle_startup_prompts(self) -> None:
@@ -401,8 +425,7 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(
                 self,
                 "Error al guardar",
-                "No se pudieron guardar las credenciales en el archivo .env.\n"
-                f"Detalle: {exc}",
+                f"No se pudieron guardar las credenciales en el archivo .env.\nDetalle: {exc}",
             )
             return
 
@@ -456,7 +479,9 @@ class MainWindow(QMainWindow):
             elif _is_windows():
                 hint += "\nDescárgalo desde https://ffmpeg.org/download.html y añade la carpeta bin al PATH."
             else:
-                hint += "\nInstálalo con tu gestor de paquetes, por ejemplo: sudo apt install ffmpeg"
+                hint += (
+                    "\nInstálalo con tu gestor de paquetes, por ejemplo: sudo apt install ffmpeg"
+                )
             return hint
         if tool == "fpcalc":
             hint = "Chromaprint (fpcalc) no se encontró en tu PATH."
@@ -504,6 +529,164 @@ class MainWindow(QMainWindow):
     def _open_api_settings(self) -> None:
         self._maybe_prompt_api_credentials(force=True)
 
+    def _setup_shortcuts(self) -> None:
+        for shortcut in self._shortcuts:
+            shortcut.setParent(None)
+        self._shortcuts.clear()
+
+        combos: list[tuple[QKeySequence, Callable[[], None]]] = []
+        if self._action_focus_search is None:
+            combos.append((QKeySequence.Find, self._focus_search))
+        if self._action_refresh is None:
+            combos.append((QKeySequence.Refresh, self.refresh_results))
+        for sequence, handler in combos:
+            shortcut = QShortcut(sequence, self)
+            shortcut.activated.connect(handler)
+            self._shortcuts.append(shortcut)
+
+    def _focus_search(self) -> None:
+        self._search.setFocus(Qt.ShortcutFocusReason)
+        self._search.selectAll()
+
+    def _clear_search(self) -> None:
+        if not self._search.text():
+            return
+        self._search_timer.stop()
+        self._search.clear()
+        self.refresh_results()
+        self._focus_search()
+        self._update_action_state()
+
+    def _select_all_rows(self) -> None:
+        self._table.setFocus(Qt.ShortcutFocusReason)
+        self._table.selectAll()
+
+    def _open_help_center(self) -> None:  # pragma: no cover - UI dialog
+        self._refresh_dependency_state()
+
+        tips = """
+        <ul>
+            <li><b>⌘F / Ctrl+F</b> enfoca la búsqueda instantáneamente.</li>
+            <li><b>Enter</b> ejecuta la consulta actual.</li>
+            <li><b>Doble clic</b> abre la pista seleccionada con tu reproductor predeterminado.</li>
+            <li><b>Clic derecho</b> muestra acciones rápidas sobre la fila.</li>
+        </ul>
+        """.strip()
+
+        dependency_lines: list[str] = []
+        ffmpeg_ok = self._dependency_state.get("ffmpeg", False)
+        fpcalc_ok = self._dependency_state.get("fpcalc", False)
+        ffmpeg_text = (
+            "✅ listo" if ffmpeg_ok else self._dependency_hint("ffmpeg").replace("\n", "<br/>")
+        )
+        dependency_lines.append(f"<li><b>ffmpeg</b>: {ffmpeg_text}</li>")
+        fpcalc_text = (
+            "✅ listo" if fpcalc_ok else self._dependency_hint("fpcalc").replace("\n", "<br/>")
+        )
+        dependency_lines.append(f"<li><b>Chromaprint (fpcalc)</b>: {fpcalc_text}</li>")
+        if self._api_key and self._musicbrainz_ua:
+            dependency_lines.append("<li><b>APIs</b>: ✅ credenciales configuradas.</li>")
+        else:
+            dependency_lines.append(
+                "<li><b>APIs</b>: Configura tu clave de AcoustID y el identificador de MusicBrainz desde «Configurar APIs…».</li>"
+            )
+
+        dependencies = "<ul>" + "".join(dependency_lines) + "</ul>"
+        message = """
+            <p style="font-size: 15px;">
+                SongSearch Organizer reúne tus herramientas en una sola vista con estética macOS.
+            </p>
+            <p><b>Atajos esenciales</b></p>
+            {tips}
+            <p><b>Estado actual</b></p>
+            {deps}
+            <p>
+                Necesitas más ayuda? Revisa el README o pulsa «Configurar APIs…» para verificar tus credenciales.
+            </p>
+        """.format(tips=tips, deps=dependencies)
+
+        dialog = QMessageBox(self)
+        dialog.setWindowTitle("Centro de ayuda")
+        dialog.setIcon(QMessageBox.Information)
+        dialog.setTextFormat(Qt.RichText)
+        dialog.setText(message)
+        dialog.setStandardButtons(QMessageBox.Close)
+        dialog.exec()
+
+    def _show_about_dialog(self) -> None:  # pragma: no cover - UI dialog
+        message = (
+            "<p><b>SongSearch Organizer</b></p>"
+            f"<p>Versión {__version__}</p>"
+            "<p>Gestiona, busca y enriquece tu biblioteca musical con AcoustID y MusicBrainz.</p>"
+        )
+        QMessageBox.about(self, "Acerca de SongSearch Organizer", message)
+
+    def _update_summary_badge(self, *, shown: int, total: int, truncated: bool) -> None:
+        if self._summary_badge is None:
+            return
+        if total <= 0:
+            self._summary_badge.setText("Sin resultados")
+            self._summary_badge.setToolTip(
+                "Escanea tu biblioteca o escribe en la búsqueda para empezar."
+            )
+            return
+        if shown == total and not truncated:
+            self._summary_badge.setText(f"{total} pistas")
+        else:
+            self._summary_badge.setText(f"{shown} / {total} pistas")
+        if truncated:
+            self._summary_badge.setToolTip(
+                f"Mostrando los primeros {shown} resultados de {total} disponibles."
+            )
+        else:
+            self._summary_badge.setToolTip("")
+
+    def _update_table_caption(
+        self,
+        *,
+        query_text: str,
+        shown: int,
+        total: int,
+        truncated: bool,
+        elapsed_ms: float,
+    ) -> None:
+        if self._table_caption is None:
+            return
+        if total == 0:
+            if query_text:
+                self._table_caption.setText("Sin coincidencias para tu búsqueda")
+            else:
+                self._table_caption.setText("Escanea una carpeta para poblar la biblioteca")
+            self._table_caption.setToolTip("")
+            return
+        base = f"{shown} pistas" if shown == total else f"{shown}/{total} pistas"
+        if truncated:
+            base += " · vista limitada"
+        self._table_caption.setText(f"{base} · {elapsed_ms:.0f} ms")
+        if query_text:
+            self._table_caption.setToolTip(f"Filtro activo: {query_text}")
+        else:
+            self._table_caption.setToolTip("")
+
+    def _update_inspector_caption(self, record: Mapping[str, Any] | None) -> None:
+        if self._inspector_caption is None:
+            return
+        if not record:
+            self._inspector_caption.setText("Selecciona una pista para ver sus metadatos")
+            self._inspector_caption.setToolTip("")
+            return
+        title = str(record.get("title") or "")
+        path_value = record.get("path")
+        if not title:
+            if isinstance(path_value, str):
+                title = Path(path_value).stem
+        artist = record.get("artist")
+        subtitle = title if title else "Pista seleccionada"
+        if artist:
+            subtitle = f"{subtitle} — {artist}"
+        self._inspector_caption.setText(subtitle)
+        self._inspector_caption.setToolTip(subtitle)
+
     # ------------------------------------------------------------------
     # UI setup
     # ------------------------------------------------------------------
@@ -518,15 +701,54 @@ class MainWindow(QMainWindow):
 
         header = QWidget(central)
         header.setObjectName("HeaderBar")
-        header_layout = QHBoxLayout(header)
-        header_layout.setContentsMargins(24, 24, 24, 12)
-        header_layout.setSpacing(16)
+        header_layout = QVBoxLayout(header)
+        header_layout.setContentsMargins(32, 32, 32, 24)
+        header_layout.setSpacing(20)
 
-        search_container = QWidget(header)
+        title_row = QHBoxLayout()
+        title_row.setContentsMargins(0, 0, 0, 0)
+        title_row.setSpacing(16)
+
+        title_block = QVBoxLayout()
+        title_block.setContentsMargins(0, 0, 0, 0)
+        title_block.setSpacing(2)
+
+        title_label = QLabel("SongSearch Organizer", header)
+        title_label.setObjectName("HeaderTitle")
+        title_block.addWidget(title_label)
+
+        subtitle_label = QLabel("Colección musical con inspiración macOS", header)
+        subtitle_label.setObjectName("HeaderSubtitle")
+        subtitle_label.setWordWrap(True)
+        title_block.addWidget(subtitle_label)
+
+        title_row.addLayout(title_block)
+        title_row.addStretch(1)
+
+        self._summary_badge = QLabel("Sin resultados", header)
+        self._summary_badge.setObjectName("SummaryBadge")
+        title_row.addWidget(self._summary_badge, 0, Qt.AlignVCenter)
+
+        self._help_button = QPushButton(_load_icon("help.png"), "Centro de ayuda", header)
+        self._help_button.setObjectName("HelpButton")
+        self._help_button.setProperty("helpButton", True)
+        self._help_button.clicked.connect(self._open_help_center)
+        title_row.addWidget(self._help_button, 0, Qt.AlignVCenter)
+
+        header_layout.addLayout(title_row)
+
+        toolbar_frame = QFrame(header)
+        toolbar_frame.setObjectName("ToolbarCard")
+        ensure_styled_background(toolbar_frame)
+        toolbar_layout = QHBoxLayout(toolbar_frame)
+        toolbar_layout.setContentsMargins(20, 16, 20, 16)
+        toolbar_layout.setSpacing(18)
+
+        search_container = QWidget(toolbar_frame)
         search_container.setObjectName("SearchContainer")
         search_layout = QHBoxLayout(search_container)
-        search_layout.setContentsMargins(0, 0, 0, 0)
-        search_layout.setSpacing(10)
+        search_layout.setContentsMargins(12, 0, 12, 0)
+        search_layout.setSpacing(12)
 
         self._search.setPlaceholderText("Buscar título, artista, álbum, género o ruta…")
         self._search.setClearButtonEnabled(True)
@@ -535,37 +757,55 @@ class MainWindow(QMainWindow):
         self._search.returnPressed.connect(self.refresh_results)
         search_layout.addWidget(self._search, 1)
 
-        search_hint = QLabel("↵ ejecutar", search_container)
+        search_hint = QLabel("⌘F / Ctrl+F", search_container)
         search_hint.setObjectName("SearchHint")
-        search_layout.addWidget(search_hint)
+        search_layout.addWidget(search_hint, 0, Qt.AlignVCenter)
 
-        header_layout.addWidget(search_container, 1, Qt.AlignVCenter)
+        toolbar_layout.addWidget(search_container, 1)
 
-        actions_container = QWidget(header)
+        actions_container = QWidget(toolbar_frame)
         actions_container.setObjectName("HeaderActions")
         actions_layout = QHBoxLayout(actions_container)
         actions_layout.setContentsMargins(0, 0, 0, 0)
-        actions_layout.setSpacing(8)
+        actions_layout.setSpacing(12)
 
-        self._btn_config = QPushButton(_load_icon("settings.png"), "Configurar APIs…", actions_container)
+        self._btn_config = QPushButton(
+            _load_icon("settings.png"), "Configurar APIs…", actions_container
+        )
+        self._btn_config.setProperty("toolbarButton", True)
         self._btn_config.clicked.connect(self._open_api_settings)
         actions_layout.addWidget(self._btn_config)
 
         self._btn_scan = QPushButton(_load_icon("scan.png"), "Escanear…", actions_container)
+        self._btn_scan.setProperty("toolbarButton", True)
         self._btn_scan.clicked.connect(self._open_scan_dialog)
         actions_layout.addWidget(self._btn_scan)
 
         self._btn_enrich = QPushButton(_load_icon("enrich.png"), "Enriquecer", actions_container)
+        self._btn_enrich.setProperty("toolbarButton", True)
         self._btn_enrich.clicked.connect(self._enrich_selected)
         self._btn_enrich.setEnabled(False)
         actions_layout.addWidget(self._btn_enrich)
 
         self._btn_spectrum = QPushButton(_load_icon("spectrum.png"), "Espectro", actions_container)
+        self._btn_spectrum.setProperty("toolbarButton", True)
         self._btn_spectrum.clicked.connect(self._generate_spectrum_selected)
         self._btn_spectrum.setEnabled(False)
         actions_layout.addWidget(self._btn_spectrum)
 
-        header_layout.addWidget(actions_container, 0, Qt.AlignRight | Qt.AlignVCenter)
+        toolbar_layout.addWidget(actions_container, 0)
+
+        for button in (
+            self._btn_config,
+            self._btn_scan,
+            self._btn_enrich,
+            self._btn_spectrum,
+            self._help_button,
+        ):
+            if button is not None:
+                button.setCursor(Qt.PointingHandCursor)
+
+        header_layout.addWidget(toolbar_frame)
         layout.addWidget(header)
 
         splitter = QSplitter(Qt.Horizontal, central)
@@ -576,8 +816,22 @@ class MainWindow(QMainWindow):
         table_card.setObjectName("TableCard")
         ensure_styled_background(table_card)
         table_layout = QVBoxLayout(table_card)
-        table_layout.setContentsMargins(18, 18, 18, 18)
-        table_layout.setSpacing(0)
+        table_layout.setContentsMargins(20, 20, 20, 20)
+        table_layout.setSpacing(12)
+
+        table_header = QVBoxLayout()
+        table_header.setContentsMargins(0, 0, 0, 0)
+        table_header.setSpacing(2)
+        table_title = QLabel("Biblioteca", table_card)
+        table_title.setObjectName("CardTitle")
+        table_header.addWidget(table_title)
+
+        self._table_caption = QLabel("Escanea una carpeta para poblar la biblioteca", table_card)
+        self._table_caption.setObjectName("CardSubtitle")
+        self._table_caption.setWordWrap(True)
+        table_header.addWidget(self._table_caption)
+
+        table_layout.addLayout(table_header)
 
         self._table.setModel(self._model)
         self._table.setSelectionBehavior(QAbstractItemView.SelectRows)
@@ -600,9 +854,25 @@ class MainWindow(QMainWindow):
         details_card.setObjectName("DetailsCard")
         ensure_styled_background(details_card)
         details_layout = QVBoxLayout(details_card)
-        details_layout.setContentsMargins(18, 18, 18, 18)
-        details_layout.setSpacing(0)
-        details_layout.addWidget(self._details)
+        details_layout.setContentsMargins(20, 20, 20, 20)
+        details_layout.setSpacing(12)
+
+        inspector_header = QVBoxLayout()
+        inspector_header.setContentsMargins(0, 0, 0, 0)
+        inspector_header.setSpacing(2)
+        inspector_title = QLabel("Inspector", details_card)
+        inspector_title.setObjectName("CardTitle")
+        inspector_header.addWidget(inspector_title)
+
+        self._inspector_caption = QLabel(
+            "Selecciona una pista para ver sus metadatos", details_card
+        )
+        self._inspector_caption.setObjectName("CardSubtitle")
+        self._inspector_caption.setWordWrap(True)
+        inspector_header.addWidget(self._inspector_caption)
+
+        details_layout.addLayout(inspector_header)
+        details_layout.addWidget(self._details, 1)
 
         for card in (table_card, details_card):
             shadow = QGraphicsDropShadowEffect(card)
@@ -626,6 +896,147 @@ class MainWindow(QMainWindow):
         selection_model = self._table.selectionModel()
         if selection_model is not None:
             selection_model.selectionChanged.connect(self._on_selection_changed)
+
+        self._update_summary_badge(shown=0, total=0, truncated=False)
+        self._update_table_caption(
+            query_text="",
+            shown=0,
+            total=0,
+            truncated=False,
+            elapsed_ms=0.0,
+        )
+        self._update_inspector_caption(None)
+
+    def _create_actions(self) -> None:
+        self._action_configure_api = QAction(_load_icon("settings.png"), "Configurar APIs…", self)
+        self._action_configure_api.setShortcut(QKeySequence(QKeySequence.StandardKey.Preferences))
+        self._action_configure_api.setStatusTip(
+            "Define las credenciales de AcoustID y MusicBrainz."
+        )
+        self._action_configure_api.setMenuRole(QAction.MenuRole.PreferencesRole)
+        self._action_configure_api.triggered.connect(self._open_api_settings)
+
+        self._action_scan = QAction(_load_icon("scan.png"), "Escanear…", self)
+        self._action_scan.setShortcut(QKeySequence("Ctrl+Shift+S"))
+        self._action_scan.setStatusTip("Explora una carpeta y añade sus pistas a la biblioteca.")
+        self._action_scan.triggered.connect(self._open_scan_dialog)
+
+        self._action_open_track = QAction(_load_icon("open.png"), "Abrir", self)
+        self._action_open_track.setShortcut(QKeySequence(QKeySequence.StandardKey.Open))
+        self._action_open_track.setStatusTip(
+            "Reproduce la pista seleccionada con la aplicación predeterminada."
+        )
+        self._action_open_track.triggered.connect(self._open_selected_track)
+
+        self._action_reveal_track = QAction(_load_icon("reveal.png"), "Mostrar en carpeta", self)
+        self._action_reveal_track.setShortcut(QKeySequence("Ctrl+Shift+R"))
+        self._action_reveal_track.setStatusTip(
+            "Abre el explorador de archivos en la ubicación de la pista."
+        )
+        self._action_reveal_track.triggered.connect(self._reveal_selected_track)
+
+        self._action_exit = QAction("Salir", self)
+        self._action_exit.setShortcut(QKeySequence(QKeySequence.StandardKey.Quit))
+        self._action_exit.setMenuRole(QAction.MenuRole.QuitRole)
+        self._action_exit.triggered.connect(self.close)
+
+        self._action_copy_paths = QAction(_load_icon("copy.png"), "Copiar ruta", self)
+        self._action_copy_paths.setShortcut(QKeySequence("Ctrl+Shift+C"))
+        self._action_copy_paths.setStatusTip("Copia la ruta de la pista al portapapeles.")
+        self._action_copy_paths.triggered.connect(self._copy_selected_paths)
+
+        self._action_focus_search = QAction("Buscar", self)
+        self._action_focus_search.setShortcut(QKeySequence(QKeySequence.StandardKey.Find))
+        self._action_focus_search.setStatusTip("Enfoca el cuadro de búsqueda.")
+        self._action_focus_search.triggered.connect(self._focus_search)
+
+        self._action_clear_search = QAction("Limpiar búsqueda", self)
+        self._action_clear_search.setShortcut(QKeySequence("Esc"))
+        self._action_clear_search.setStatusTip("Limpia el texto de búsqueda actual.")
+        self._action_clear_search.triggered.connect(self._clear_search)
+
+        self._action_select_all = QAction("Seleccionar todo", self)
+        self._action_select_all.setShortcut(QKeySequence(QKeySequence.StandardKey.SelectAll))
+        self._action_select_all.setStatusTip("Selecciona todas las filas visibles.")
+        self._action_select_all.triggered.connect(self._select_all_rows)
+
+        self._action_refresh = QAction(_load_icon("refresh.png"), "Actualizar resultados", self)
+        self._action_refresh.setShortcut(QKeySequence(QKeySequence.StandardKey.Refresh))
+        self._action_refresh.setStatusTip("Vuelve a ejecutar la búsqueda actual.")
+        self._action_refresh.triggered.connect(self.refresh_results)
+
+        self._action_enrich = QAction(_load_icon("enrich.png"), "Enriquecer", self)
+        self._action_enrich.setShortcut(QKeySequence("Ctrl+E"))
+        self._action_enrich.setStatusTip("Busca metadatos en AcoustID y MusicBrainz.")
+        self._action_enrich.triggered.connect(self._enrich_selected)
+
+        self._action_spectrum = QAction(_load_icon("spectrum.png"), "Espectro", self)
+        self._action_spectrum.setShortcut(QKeySequence("Ctrl+Shift+E"))
+        self._action_spectrum.setStatusTip("Genera el espectro de la pista seleccionada.")
+        self._action_spectrum.triggered.connect(self._generate_spectrum_selected)
+
+        self._action_help_overview = QAction(_load_icon("help.png"), "Centro de ayuda", self)
+        self._action_help_overview.setShortcut(QKeySequence(QKeySequence.StandardKey.HelpContents))
+        self._action_help_overview.setStatusTip("Descubre atajos, dependencias y consejos de uso.")
+        self._action_help_overview.setMenuRole(QAction.MenuRole.HelpRole)
+        self._action_help_overview.triggered.connect(self._open_help_center)
+
+        self._action_about = QAction("Acerca de SongSearch Organizer", self)
+        self._action_about.setMenuRole(QAction.MenuRole.AboutRole)
+        self._action_about.triggered.connect(self._show_about_dialog)
+
+        for action in (
+            self._action_configure_api,
+            self._action_scan,
+            self._action_open_track,
+            self._action_reveal_track,
+            self._action_exit,
+            self._action_copy_paths,
+            self._action_focus_search,
+            self._action_clear_search,
+            self._action_select_all,
+            self._action_refresh,
+            self._action_enrich,
+            self._action_spectrum,
+            self._action_help_overview,
+            self._action_about,
+        ):
+            if action is not None:
+                self.addAction(action)
+
+        self._update_action_state()
+
+    def _build_menus(self) -> None:
+        menu_bar: QMenuBar = self.menuBar()
+        menu_bar.clear()
+
+        def add_group(menu: QMenu, *actions: QAction | None) -> None:
+            valid_actions = [action for action in actions if action is not None]
+            if not valid_actions:
+                return
+            if menu.actions():
+                menu.addSeparator()
+            for action in valid_actions:
+                menu.addAction(action)
+
+        file_menu = menu_bar.addMenu("&Archivo")
+        add_group(file_menu, self._action_configure_api, self._action_scan)
+        add_group(file_menu, self._action_open_track, self._action_reveal_track)
+        add_group(file_menu, self._action_exit)
+
+        edit_menu = menu_bar.addMenu("&Edición")
+        add_group(edit_menu, self._action_copy_paths)
+        add_group(edit_menu, self._action_focus_search, self._action_clear_search)
+        add_group(edit_menu, self._action_select_all)
+
+        tools_menu = menu_bar.addMenu("&Herramientas")
+        add_group(tools_menu, self._action_refresh)
+        add_group(tools_menu, self._action_enrich, self._action_spectrum)
+
+        help_menu = menu_bar.addMenu("Ay&uda")
+        for action in (self._action_help_overview, self._action_about):
+            if action is not None:
+                help_menu.addAction(action)
 
     # ------------------------------------------------------------------
     # Actions
@@ -676,13 +1087,18 @@ class MainWindow(QMainWindow):
         self._scan_worker = worker
         if self._btn_scan is not None:
             self._btn_scan.setEnabled(False)
+        if self._action_scan is not None:
+            self._action_scan.setEnabled(False)
         self._status.showMessage(f"Escaneando {directory}…")
         worker.start()
 
     def _reset_scan_worker(self) -> None:
         if self._btn_scan is not None:
             self._btn_scan.setEnabled(True)
+        if self._action_scan is not None:
+            self._action_scan.setEnabled(True)
         self._scan_worker = None
+        self._update_action_state()
 
     def _on_scan_finished(self, directory: Path) -> None:
         self._status.showMessage(f"Escaneo completado: {directory}", 5000)
@@ -813,6 +1229,7 @@ class MainWindow(QMainWindow):
     # ------------------------------------------------------------------
     def _on_search_text_changed(self, _: str) -> None:
         self._search_timer.start()
+        self._update_action_state()
 
     def _on_selection_changed(
         self, selected: QItemSelection, _: QItemSelection
@@ -820,6 +1237,7 @@ class MainWindow(QMainWindow):
         if not selected.indexes():
             self._current_path = None
             self._details.clear_details()
+            self._update_inspector_caption(None)
             self._update_action_state()
             return
         index = selected.indexes()[0]
@@ -827,14 +1245,17 @@ class MainWindow(QMainWindow):
         if not data:
             self._current_path = None
             self._details.clear_details()
+            self._update_inspector_caption(None)
             self._update_action_state()
             return
         path = data.get("path")
         self._current_path = path if isinstance(path, str) else None
         if self._current_path:
             self._details.show_for_path(self._current_path, record=data)
+            self._update_inspector_caption(data)
         else:
             self._details.clear_details()
+            self._update_inspector_caption(None)
         self._update_action_state()
 
     # ------------------------------------------------------------------
@@ -893,10 +1314,19 @@ class MainWindow(QMainWindow):
             search_hint=search_hint,
         )
         self._status.showMessage(message)
+        self._update_summary_badge(shown=shown, total=total, truncated=truncated)
+        self._update_table_caption(
+            query_text=query_text,
+            shown=shown,
+            total=total,
+            truncated=truncated,
+            elapsed_ms=elapsed_ms,
+        )
 
         if shown == 0:
             self._details.clear_details()
             self._current_path = None
+            self._update_inspector_caption(None)
         self._update_action_state()
 
     def _format_status_message(
@@ -994,22 +1424,59 @@ class MainWindow(QMainWindow):
 
     def _update_action_state(self) -> None:
         has_selection = bool(self._current_path)
+        has_rows = self._model.rowCount() > 0 if self._model is not None else False
+        search_has_text = bool(self._search.text())
+        enable_enrich = has_selection and self._can_enrich_metadata
+        enrich_hint = (
+            self._enrich_disabled_reason or "Configura las APIs para habilitar el enriquecimiento."
+        )
+        enable_spectrum = has_selection and self._can_generate_spectrum
+        spectrum_hint = self._spectrum_disabled_reason or "Instala ffmpeg para generar espectros."
+
         if self._btn_enrich is not None:
-            enable_enrich = has_selection and self._can_enrich_metadata
             self._btn_enrich.setEnabled(enable_enrich)
             if enable_enrich:
                 self._btn_enrich.setToolTip("")
             else:
-                hint = self._enrich_disabled_reason or "Configura las APIs para habilitar el enriquecimiento."
-                self._btn_enrich.setToolTip(hint)
+                self._btn_enrich.setToolTip(enrich_hint)
+        if self._action_enrich is not None:
+            self._action_enrich.setEnabled(enable_enrich)
+            if enable_enrich:
+                self._action_enrich.setStatusTip("Busca metadatos en AcoustID y MusicBrainz.")
+            else:
+                self._action_enrich.setStatusTip(enrich_hint)
+
         if self._btn_spectrum is not None:
-            enable_spectrum = has_selection and self._can_generate_spectrum
             self._btn_spectrum.setEnabled(enable_spectrum)
             if enable_spectrum:
                 self._btn_spectrum.setToolTip("")
             else:
-                hint = self._spectrum_disabled_reason or "Instala ffmpeg para generar espectros."
-                self._btn_spectrum.setToolTip(hint)
+                self._btn_spectrum.setToolTip(spectrum_hint)
+        if self._action_spectrum is not None:
+            self._action_spectrum.setEnabled(enable_spectrum)
+            if enable_spectrum:
+                self._action_spectrum.setStatusTip("Genera el espectro de la pista seleccionada.")
+            else:
+                self._action_spectrum.setStatusTip(spectrum_hint)
+
+        if self._action_open_track is not None:
+            self._action_open_track.setEnabled(has_selection)
+        if self._action_reveal_track is not None:
+            self._action_reveal_track.setEnabled(has_selection)
+        if self._action_copy_paths is not None:
+            self._action_copy_paths.setEnabled(has_selection)
+
+        if self._action_clear_search is not None:
+            self._action_clear_search.setEnabled(search_has_text)
+
+        if self._action_select_all is not None:
+            self._action_select_all.setEnabled(has_rows)
+
+        if self._action_refresh is not None:
+            self._action_refresh.setEnabled(self._con is not None)
+
+        if self._action_focus_search is not None:
+            self._action_focus_search.setEnabled(True)
 
     def _resolve_db_path(self, con: sqlite3.Connection | None) -> Path | None:
         if con is None:

--- a/songsearch/ui/theme.py
+++ b/songsearch/ui/theme.py
@@ -18,152 +18,139 @@ from PySide6.QtWidgets import QApplication, QWidget
 # Qt style sheet
 # --------------------------------------------------------------------------------------
 THEME_CSS = """
-/* Base colours */
+/* Base surface */
 QWidget {
-    background-color: #0f111a;
-    color: #f1f4ff;
-    font-family: "Inter", "Segoe UI", sans-serif;
-    font-size: 14px;
+    background-color: #0c0f1c;
+    color: #f5f8ff;
+    font-family: "Inter", "SF Pro Display", "Segoe UI", sans-serif;
+    font-size: 15px;
 }
 
 QMainWindow, QWidget#MainContainer {
-    background-color: #0f111a;
+    background-color: #0c0f1c;
 }
 
+/* Header */
 #HeaderBar {
-    background-color: #14192b;
-    border-bottom: 1px solid #1f2944;
-    padding: 12px 18px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #1a2135, stop:1 #121727);
+    border-bottom: 1px solid #202947;
+}
+
+#HeaderTitle {
+    font-size: 26px;
+    font-weight: 600;
+    color: #f9faff;
+}
+
+#HeaderSubtitle {
+    color: #9aa5c5;
+    font-size: 13px;
+}
+
+QLabel#SummaryBadge {
+    background-color: rgba(77, 118, 255, 0.28);
+    color: #e3ebff;
+    padding: 6px 16px;
+    border-radius: 16px;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+QFrame#ToolbarCard {
+    background-color: rgba(24, 31, 52, 220);
+    border: 1px solid rgba(86, 115, 196, 90);
+    border-radius: 24px;
 }
 
 #SearchContainer {
-    background-color: rgba(10, 13, 22, 160);
-    border: 1px solid #1f2944;
-    border-radius: 16px;
-    padding: 14px 18px;
+    background-color: rgba(10, 14, 26, 210);
+    border-radius: 20px;
+    border: 1px solid rgba(90, 116, 196, 80);
 }
 
 QLineEdit#SearchField {
-    background-color: rgba(4, 6, 12, 220);
-    border: 1px solid #1f2944;
-    border-radius: 18px;
-    padding: 8px 14px;
-    selection-background-color: #3a6ff1;
+    background-color: transparent;
+    border: none;
+    padding: 8px 12px;
+    selection-background-color: #4c6ff6;
     selection-color: #ffffff;
 }
 
 QLineEdit#SearchField:focus {
-    border: 1px solid #3a6ff1;
+    outline: none;
 }
 
 QLabel#SearchHint {
-    color: #7b88a8;
+    color: #8f9ac1;
     font-size: 12px;
 }
 
-QFrame#TableCard,
-QFrame#DetailsCard {
-    background-color: #14192b;
-    border: 1px solid #1f2944;
-    border-radius: 18px;
-}
-
-QTableView {
-    background-color: transparent;
-    alternate-background-color: rgba(29, 38, 66, 120);
-    gridline-color: #1f2944;
-    selection-background-color: #2b3f87;
-    selection-color: #f5f7ff;
-}
-
-QTableView::item:hover {
-    background-color: rgba(43, 63, 135, 80);
-}
-
-QHeaderView::section {
-    background-color: transparent;
-    color: #9ca6c3;
-    border: none;
-    border-right: 1px solid #1f2944;
-    padding: 6px 10px;
-}
-
-QHeaderView::section:horizontal:last {
-    border-right: none;
-}
-
-QScrollBar:vertical {
-    background: transparent;
-    width: 12px;
-    margin: 8px 0;
-}
-
-QScrollBar::handle:vertical {
-    background: rgba(70, 82, 118, 180);
-    min-height: 48px;
-    border-radius: 6px;
-}
-
-QScrollBar::handle:vertical:hover {
-    background: rgba(90, 110, 170, 200);
-}
-
-QScrollBar::add-line:vertical,
-QScrollBar::sub-line:vertical {
-    height: 0px;
-}
-
-QScrollBar::sub-page:vertical,
-QScrollBar::add-page:vertical {
-    background: none;
-}
-
-QScrollBar:horizontal {
-    background: transparent;
-    height: 12px;
-    margin: 0 8px;
-}
-
-QScrollBar::handle:horizontal {
-    background: rgba(70, 82, 118, 180);
-    min-width: 48px;
-    border-radius: 6px;
-}
-
-QScrollBar::handle:horizontal:hover {
-    background: rgba(90, 110, 170, 200);
-}
-
-QScrollBar::add-line:horizontal,
-QScrollBar::sub-line:horizontal {
-    width: 0px;
-}
-
-QScrollBar::sub-page:horizontal,
-QScrollBar::add-page:horizontal {
-    background: none;
-}
-
+/* Buttons */
 QPushButton {
-    background-color: #202a46;
-    border-radius: 18px;
-    padding: 8px 18px;
-    border: 1px solid transparent;
-    color: #e9ecf8;
+    background-color: rgba(38, 48, 76, 220);
+    border-radius: 20px;
+    padding: 10px 20px;
+    border: 1px solid rgba(95, 116, 180, 60);
+    color: #eef1ff;
+    font-weight: 500;
 }
 
 QPushButton:hover {
-    background-color: #263152;
+    background-color: rgba(52, 66, 104, 240);
 }
 
 QPushButton:pressed {
-    background-color: #1c2640;
+    background-color: rgba(35, 46, 74, 255);
 }
 
 QPushButton:disabled {
-    background-color: rgba(32, 42, 70, 80);
-    color: rgba(233, 236, 248, 70);
+    background-color: rgba(34, 42, 66, 120);
+    color: rgba(224, 228, 248, 90);
     border-color: transparent;
+}
+
+QPushButton[toolbarButton="true"] {
+    background-color: rgba(73, 98, 182, 210);
+    color: #ffffff;
+    font-weight: 600;
+    padding: 10px 24px;
+    border: 1px solid rgba(118, 148, 236, 120);
+}
+
+QPushButton[toolbarButton="true"]:hover {
+    background-color: rgba(96, 124, 218, 230);
+}
+
+QPushButton[toolbarButton="true"]:pressed {
+    background-color: rgba(63, 86, 164, 220);
+}
+
+QPushButton[helpButton="true"] {
+    background-color: rgba(96, 132, 255, 210);
+    border: 1px solid rgba(140, 165, 255, 150);
+    color: #ffffff;
+    font-weight: 600;
+}
+
+QPushButton[helpButton="true"]:hover {
+    background-color: rgba(118, 152, 255, 230);
+}
+
+QPushButton[helpButton="true"]:pressed {
+    background-color: rgba(84, 120, 230, 220);
+}
+
+QPushButton[secondaryButton="true"] {
+    background-color: rgba(30, 38, 60, 220);
+    border: 1px solid rgba(76, 98, 158, 80);
+    color: #e6e9f9;
+}
+
+QPushButton[tonalButton="true"] {
+    background-color: rgba(86, 120, 240, 210);
+    border: 1px solid rgba(116, 150, 255, 140);
+    color: #ffffff;
+    font-weight: 600;
 }
 
 QPushButton[accentButton="true"] {
@@ -179,19 +166,136 @@ QPushButton[accentButton="true"]:pressed {
     background-color: #335fd1;
 }
 
+/* Cards */
+QFrame#TableCard,
+QFrame#DetailsCard {
+    background-color: rgba(18, 23, 39, 240);
+    border: 1px solid rgba(60, 74, 120, 120);
+    border-radius: 24px;
+}
+
+QLabel#CardTitle {
+    color: #f4f6ff;
+    font-size: 17px;
+    font-weight: 600;
+}
+
+QLabel#CardSubtitle {
+    color: #99a5cb;
+    font-size: 13px;
+}
+
+QLabel#DetailsHeadline {
+    color: #f7f9ff;
+    font-size: 20px;
+    font-weight: 600;
+}
+
+QLabel#DetailsSubheadline {
+    color: #a2aed0;
+    font-size: 13px;
+}
+
 QLabel[formLabel="true"] {
-    color: #7b88a8;
+    color: #8a94b6;
     font-weight: 600;
 }
 
 QLabel[valueLabel="true"] {
-    color: #e9ecf8;
+    color: #f1f4ff;
 }
 
+QFrame#DetailsActions {
+    background-color: rgba(16, 22, 38, 200);
+    border: 1px solid rgba(66, 84, 140, 100);
+    border-radius: 18px;
+}
+
+/* Table */
+QTableView {
+    background-color: transparent;
+    alternate-background-color: rgba(30, 38, 63, 140);
+    gridline-color: rgba(46, 60, 100, 160);
+    selection-background-color: rgba(80, 120, 230, 200);
+    selection-color: #f5f8ff;
+    border: none;
+}
+
+QTableView::item:hover {
+    background-color: rgba(80, 120, 230, 60);
+}
+
+QHeaderView::section {
+    background-color: transparent;
+    color: #9aa5c8;
+    border: none;
+    border-right: 1px solid rgba(60, 74, 120, 120);
+    padding: 6px 10px;
+    font-weight: 500;
+}
+
+QHeaderView::section:horizontal:last {
+    border-right: none;
+}
+
+/* Scrollbars */
+QScrollBar:vertical {
+    background: transparent;
+    width: 12px;
+    margin: 10px 0;
+}
+
+QScrollBar::handle:vertical {
+    background: rgba(86, 112, 178, 200);
+    min-height: 48px;
+    border-radius: 6px;
+}
+
+QScrollBar::handle:vertical:hover {
+    background: rgba(108, 134, 204, 220);
+}
+
+QScrollBar::add-line:vertical,
+QScrollBar::sub-line:vertical {
+    height: 0px;
+}
+
+QScrollBar::sub-page:vertical,
+QScrollBar::add-page:vertical {
+    background: none;
+}
+
+QScrollBar:horizontal {
+    background: transparent;
+    height: 12px;
+    margin: 0 10px;
+}
+
+QScrollBar::handle:horizontal {
+    background: rgba(86, 112, 178, 200);
+    min-width: 48px;
+    border-radius: 6px;
+}
+
+QScrollBar::handle:horizontal:hover {
+    background: rgba(108, 134, 204, 220);
+}
+
+QScrollBar::add-line:horizontal,
+QScrollBar::sub-line:horizontal {
+    width: 0px;
+}
+
+QScrollBar::sub-page:horizontal,
+QScrollBar::add-page:horizontal {
+    background: none;
+}
+
+/* Status bar & dialogs */
 QStatusBar#MainStatusBar {
-    background-color: #14192b;
-    border-top: 1px solid #1f2944;
-    color: #9ca6c3;
+    background-color: rgba(18, 23, 39, 240);
+    border-top: 1px solid rgba(52, 66, 110, 120);
+    color: #9fa9c8;
 }
 
 QMessageBox {
@@ -199,7 +303,7 @@ QMessageBox {
 }
 
 QToolTip {
-    background-color: #3a6ff1;
+    background-color: #4c6ff6;
     color: #ffffff;
     padding: 6px 8px;
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- reintroduce the menu bar with platform-aware actions that mirror the redesigned toolbar controls
- add helpers for clearing the search box, selecting all results, and presenting an about dialog through the help menu
- keep action enablement in sync with selection, dependency checks, and scan progress so menu items follow the toolbar state

## Testing
- ruff format --check .

------
https://chatgpt.com/codex/tasks/task_e_68c8aec149dc832ca5f57d4fc8615ba9