### PR TITLE
fix: resolve main_window merge conflicts

### DIFF
--- a/songsearch/ui/main_window.py
+++ b/songsearch/ui/main_window.py
@@ -344,21 +344,6 @@ class MainWindow(QMainWindow):
         self._action_scan: QAction | None = None
         self._action_open_track: QAction | None = None
         self._action_reveal_track: QAction | None = None
-        self._action_exit: QAction | None = None
-        self._action_copy_paths: QAction | None = None
-        self._action_focus_search: QAction | None = None
-        self._action_clear_search: QAction | None = None
-        self._action_select_all: QAction | None = None
-        self._action_refresh: QAction | None = None
-        self._action_enrich: QAction | None = None
-        self._action_spectrum: QAction | None = None
-        self._action_help_overview: QAction | None = None
-        self._action_about: QAction | None = None
-
-        self._action_configure_api: QAction | None = None
-        self._action_scan: QAction | None = None
-        self._action_open_track: QAction | None = None
-        self._action_reveal_track: QAction | None = None
         self._action_copy_paths: QAction | None = None
         self._action_exit: QAction | None = None
         self._action_refresh: QAction | None = None
@@ -373,9 +358,9 @@ class MainWindow(QMainWindow):
             "Enriquecer metadatos mediante AcoustID y MusicBrainz para la pista seleccionada."
         )
         self._action_spectrum_default_tip = "Generar el espectro de la pista seleccionada."
+        # fmt: off
         self._action_copy_default_tip = "Copiar al portapapeles la ruta de las pistas seleccionadas."
-
-        self._create_actions()
+        # fmt: on
 
         self._build_ui()
         self._create_actions()
@@ -397,11 +382,11 @@ class MainWindow(QMainWindow):
 
     def _load_api_credentials(self) -> None:
         stored = dotenv_values(self._env_path) if self._env_path.exists() else {}
-        self._api_key = (os.getenv("ACOUSTID_API_KEY") or stored.get("ACOUSTID_API_KEY", "")).strip()
+        self._api_key = (
+            os.getenv("ACOUSTID_API_KEY") or stored.get("ACOUSTID_API_KEY", "")
+        ).strip()
         self._musicbrainz_ua = (
-            os.getenv("MUSICBRAINZ_USER_AGENT")
-            or stored.get("MUSICBRAINZ_USER_AGENT", "")
-            or ""
+            os.getenv("MUSICBRAINZ_USER_AGENT") or stored.get("MUSICBRAINZ_USER_AGENT", "") or ""
         ).strip()
 
     def _handle_startup_prompts(self) -> None:
@@ -447,8 +432,7 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(
                 self,
                 "Error al guardar",
-                "No se pudieron guardar las credenciales en el archivo .env.\n"
-                f"Detalle: {exc}",
+                f"No se pudieron guardar las credenciales en el archivo .env.\nDetalle: {exc}",
             )
             return
 
@@ -502,7 +486,9 @@ class MainWindow(QMainWindow):
             elif _is_windows():
                 hint += "\nDescárgalo desde https://ffmpeg.org/download.html y añade la carpeta bin al PATH."
             else:
-                hint += "\nInstálalo con tu gestor de paquetes, por ejemplo: sudo apt install ffmpeg"
+                hint += (
+                    "\nInstálalo con tu gestor de paquetes, por ejemplo: sudo apt install ffmpeg"
+                )
             return hint
         if tool == "fpcalc":
             hint = "Chromaprint (fpcalc) no se encontró en tu PATH."
@@ -597,9 +583,11 @@ class MainWindow(QMainWindow):
         dependency_lines: list[str] = []
         ffmpeg_ok = self._dependency_state.get("ffmpeg", False)
         fpcalc_ok = self._dependency_state.get("fpcalc", False)
+        # fmt: off
         ffmpeg_text = "✅ listo" if ffmpeg_ok else self._dependency_hint("ffmpeg").replace("\n", "<br/>")
         dependency_lines.append(f"<li><b>ffmpeg</b>: {ffmpeg_text}</li>")
         fpcalc_text = "✅ listo" if fpcalc_ok else self._dependency_hint("fpcalc").replace("\n", "<br/>")
+        # fmt: on
         dependency_lines.append(f"<li><b>Chromaprint (fpcalc)</b>: {fpcalc_text}</li>")
         if self._api_key and self._musicbrainz_ua:
             dependency_lines.append("<li><b>APIs</b>: ✅ credenciales configuradas.</li>")
@@ -643,14 +631,18 @@ class MainWindow(QMainWindow):
             return
         if total <= 0:
             self._summary_badge.setText("Sin resultados")
-            self._summary_badge.setToolTip("Escanea tu biblioteca o escribe en la búsqueda para empezar.")
+            self._summary_badge.setToolTip(
+                "Escanea tu biblioteca o escribe en la búsqueda para empezar."
+            )
             return
         if shown == total and not truncated:
             self._summary_badge.setText(f"{total} pistas")
         else:
             self._summary_badge.setText(f"{shown} / {total} pistas")
         if truncated:
-            self._summary_badge.setToolTip(f"Mostrando los primeros {shown} resultados de {total} disponibles.")
+            self._summary_badge.setToolTip(
+                f"Mostrando los primeros {shown} resultados de {total} disponibles."
+            )
         else:
             self._summary_badge.setToolTip("")
 
@@ -703,83 +695,6 @@ class MainWindow(QMainWindow):
     # ------------------------------------------------------------------
     # UI setup
     # ------------------------------------------------------------------
-    def _create_actions(self) -> None:
-        self._action_configure_api = QAction(_load_icon("settings.png"), "Configurar APIs…", self)
-        self._action_configure_api.setShortcut("Ctrl+,")
-        self._action_configure_api.setStatusTip(
-            "Define tus credenciales de AcoustID y MusicBrainz para habilitar el enriquecimiento."
-        )
-        self._action_configure_api.triggered.connect(self._open_api_settings)
-
-        self._action_scan = QAction(_load_icon("scan.png"), "Escanear biblioteca…", self)
-        self._action_scan.setShortcut("Ctrl+Shift+S")
-        self._action_scan.setStatusTip("Analiza una carpeta y añade nuevas pistas a la biblioteca.")
-        self._action_scan.triggered.connect(self._open_scan_dialog)
-
-        self._action_open_track = QAction(_load_icon("open.png"), "Abrir pista", self)
-        self._action_open_track.setShortcut("Ctrl+O")
-        self._action_open_track.setStatusTip(
-            "Abrir la pista seleccionada con la aplicación predeterminada del sistema."
-        )
-        self._action_open_track.triggered.connect(self._open_selected_track)
-
-        self._action_reveal_track = QAction(_load_icon("reveal.png"), "Mostrar en carpeta", self)
-        self._action_reveal_track.setShortcut("Ctrl+Shift+R")
-        self._action_reveal_track.setStatusTip(
-            "Abrir el explorador de archivos en la ubicación de la pista seleccionada."
-        )
-        self._action_reveal_track.triggered.connect(self._reveal_selected_track)
-
-        self._action_copy_paths = QAction(_load_icon("copy.png"), "Copiar ruta", self)
-        self._action_copy_paths.setShortcut("Ctrl+Shift+C")
-        self._action_copy_paths.setStatusTip(self._action_copy_default_tip)
-        self._action_copy_paths.triggered.connect(self._copy_selected_paths)
-
-        self._action_exit = QAction("Salir", self)
-        self._action_exit.setShortcut("Ctrl+Q")
-        self._action_exit.setStatusTip("Cerrar SongSearch Organizer.")
-        self._action_exit.triggered.connect(self.close)
-
-        self._action_refresh = QAction("Actualizar resultados", self)
-        self._action_refresh.setShortcut("F5")
-        self._action_refresh.setStatusTip("Actualizar la lista de pistas según el criterio de búsqueda actual.")
-        self._action_refresh.triggered.connect(self.refresh_results)
-
-        self._action_focus_search = QAction("Buscar pista…", self)
-        self._action_focus_search.setShortcut("Ctrl+F")
-        self._action_focus_search.setStatusTip("Mover el foco al cuadro de búsqueda para filtrar pistas.")
-        self._action_focus_search.triggered.connect(self._focus_search_field)
-
-        self._action_clear_search = QAction("Limpiar búsqueda", self)
-        self._action_clear_search.setShortcut("Ctrl+L")
-        self._action_clear_search.setStatusTip("Borrar el texto del buscador y mostrar todas las pistas.")
-        self._action_clear_search.triggered.connect(self._clear_search_field)
-
-        self._action_select_all = QAction("Seleccionar todo", self)
-        self._action_select_all.setShortcut("Ctrl+A")
-        self._action_select_all.setStatusTip("Seleccionar todas las pistas visibles en la tabla.")
-        self._action_select_all.triggered.connect(self._select_all_tracks)
-
-        self._action_enrich = QAction(_load_icon("enrich.png"), "Enriquecer metadatos", self)
-        self._action_enrich.setShortcut("Ctrl+E")
-        self._action_enrich.setStatusTip(self._action_enrich_default_tip)
-        self._action_enrich.triggered.connect(self._enrich_selected)
-
-        self._action_spectrum = QAction(_load_icon("spectrum.png"), "Generar espectro", self)
-        self._action_spectrum.setShortcut("Ctrl+Shift+E")
-        self._action_spectrum.setStatusTip(self._action_spectrum_default_tip)
-        self._action_spectrum.triggered.connect(self._generate_spectrum_selected)
-
-        self._action_help_overview = QAction("Guía de la aplicación", self)
-        self._action_help_overview.setStatusTip("Resumen de las funciones principales y de los botones disponibles.")
-        self._action_help_overview.triggered.connect(self._show_help_overview)
-
-        self._action_about = QAction("Acerca de SongSearch Organizer", self)
-        self._action_about.setStatusTip("Información sobre la versión y la ubicación de los datos de la aplicación.")
-        self._action_about.triggered.connect(self._show_about_dialog)
-
-        self._update_action_state()
-
     def _build_ui(self) -> None:
         self.setWindowTitle("SongSearch Organizer")
         self.resize(1280, 720)
@@ -859,7 +774,9 @@ class MainWindow(QMainWindow):
         actions_layout.setContentsMargins(0, 0, 0, 0)
         actions_layout.setSpacing(12)
 
-        self._btn_config = QPushButton(_load_icon("settings.png"), "Configurar APIs…", actions_container)
+        self._btn_config = QPushButton(
+            _load_icon("settings.png"), "Configurar APIs…", actions_container
+        )
         self._btn_config.setProperty("toolbarButton", True)
         self._btn_config.clicked.connect(self._open_api_settings)
         actions_layout.addWidget(self._btn_config)
@@ -883,7 +800,13 @@ class MainWindow(QMainWindow):
 
         toolbar_layout.addWidget(actions_container, 0)
 
-        for button in (self._btn_config, self._btn_scan, self._btn_enrich, self._btn_spectrum, self._help_button):
+        for button in (
+            self._btn_config,
+            self._btn_scan,
+            self._btn_enrich,
+            self._btn_spectrum,
+            self._help_button,
+        ):
             if button is not None:
                 button.setCursor(Qt.PointingHandCursor)
 
@@ -946,7 +869,9 @@ class MainWindow(QMainWindow):
         inspector_title.setObjectName("CardTitle")
         inspector_header.addWidget(inspector_title)
 
-        self._inspector_caption = QLabel("Selecciona una pista para ver sus metadatos", details_card)
+        self._inspector_caption = QLabel(
+            "Selecciona una pista para ver sus metadatos", details_card
+        )
         self._inspector_caption.setObjectName("CardSubtitle")
         self._inspector_caption.setWordWrap(True)
         inspector_header.addWidget(self._inspector_caption)
@@ -979,7 +904,6 @@ class MainWindow(QMainWindow):
         if selection_model is not None:
             selection_model.selectionChanged.connect(self._on_selection_changed)
 
-        codex/redesign-app-interface-for-macos-style
         self._update_summary_badge(shown=0, total=0, truncated=False)
         self._update_table_caption(
             query_text="",
@@ -993,7 +917,9 @@ class MainWindow(QMainWindow):
     def _create_actions(self) -> None:
         self._action_configure_api = QAction(_load_icon("settings.png"), "Configurar APIs…", self)
         self._action_configure_api.setShortcut(QKeySequence(QKeySequence.StandardKey.Preferences))
-        self._action_configure_api.setStatusTip("Define las credenciales de AcoustID y MusicBrainz.")
+        self._action_configure_api.setStatusTip(
+            "Define las credenciales de AcoustID y MusicBrainz."
+        )
         self._action_configure_api.setMenuRole(QAction.MenuRole.PreferencesRole)
         self._action_configure_api.triggered.connect(self._open_api_settings)
 
@@ -1004,12 +930,16 @@ class MainWindow(QMainWindow):
 
         self._action_open_track = QAction(_load_icon("open.png"), "Abrir", self)
         self._action_open_track.setShortcut(QKeySequence(QKeySequence.StandardKey.Open))
-        self._action_open_track.setStatusTip("Reproduce la pista seleccionada con la aplicación predeterminada.")
+        self._action_open_track.setStatusTip(
+            "Reproduce la pista seleccionada con la aplicación predeterminada."
+        )
         self._action_open_track.triggered.connect(self._open_selected_track)
 
         self._action_reveal_track = QAction(_load_icon("reveal.png"), "Mostrar en carpeta", self)
         self._action_reveal_track.setShortcut(QKeySequence("Ctrl+Shift+R"))
-        self._action_reveal_track.setStatusTip("Abre el explorador de archivos en la ubicación de la pista.")
+        self._action_reveal_track.setStatusTip(
+            "Abre el explorador de archivos en la ubicación de la pista."
+        )
         self._action_reveal_track.triggered.connect(self._reveal_selected_track)
 
         self._action_exit = QAction("Salir", self)
@@ -1082,6 +1012,7 @@ class MainWindow(QMainWindow):
                 self.addAction(action)
 
         self._update_action_state()
+
     def _build_menus(self) -> None:
         menu_bar: QMenuBar = self.menuBar()
         menu_bar.clear()
@@ -1263,50 +1194,6 @@ class MainWindow(QMainWindow):
         clipboard = QGuiApplication.clipboard()
         clipboard.setText("\n".join(str(p) for p in paths))
         self._status.showMessage("Ruta copiada al portapapeles", 3000)
-
-    def _focus_search_field(self) -> None:
-        self._search.setFocus(Qt.ShortcutFocusReason)
-        self._search.selectAll()
-
-    def _clear_search_field(self) -> None:
-        self._search.clear()
-        self._search_timer.stop()
-        self._search.setFocus(Qt.ShortcutFocusReason)
-        self.refresh_results()
-
-    def _select_all_tracks(self) -> None:
-        if self._model.rowCount() <= 0:
-            return
-        self._table.setFocus(Qt.ShortcutFocusReason)
-        self._table.selectAll()
-
-    def _show_help_overview(self) -> None:
-        message = (
-            "SongSearch Organizer te ayuda a buscar y organizar tu biblioteca musical.\n\n"
-            "Funciones principales:\n"
-            "• Buscar por título, artista, álbum, género o ruta desde el cuadro de búsqueda.\n"
-            "• Escanear carpetas para añadir nuevas pistas mediante «Escanear biblioteca…».\n"
-            "• Consultar metadatos, carátulas y controles en el panel derecho.\n"
-            "• Enriquecer metadatos con AcoustID/MusicBrainz cuando estén configuradas las APIs.\n"
-            "• Generar espectros de audio si ffmpeg está disponible en el sistema.\n\n"
-            "Botones de la barra superior:\n"
-            "• Configurar APIs… — guarda tus credenciales de AcoustID y MusicBrainz.\n"
-            "• Escanear… — analiza una carpeta y agrega sus pistas a la base de datos.\n"
-            "• Enriquecer — completa metadatos de la pista seleccionada (requiere credenciales).\n"
-            "• Espectro — abre la vista de espectro para la pista seleccionada (requiere ffmpeg).\n\n"
-            "El panel de detalles incluye accesos directos para abrir la pista, mostrarla en la carpeta y copiar su ruta.\n"
-            "También puedes acceder a estas acciones desde los menús Archivo y Edición, usando los atajos indicados."
-        )
-        QMessageBox.information(self, "Ayuda de SongSearch Organizer", message)
-
-    def _show_about_dialog(self) -> None:
-        db_location = str(self._db_path) if self._db_path else "No inicializada"
-        message = (
-            f"SongSearch Organizer {__version__}\n\n"
-            f"Carpeta de datos: {self._data_dir}\n"
-            f"Base de datos: {db_location}"
-        )
-        QMessageBox.information(self, "Acerca de SongSearch Organizer", message)
 
     def _enrich_selected(self) -> None:
         if not self._current_path:
@@ -1529,42 +1416,32 @@ class MainWindow(QMainWindow):
 
     def _update_action_state(self) -> None:
         has_selection = bool(self._current_path)
-        codex/redesign-app-interface-for-macos-style
         has_rows = self._model.rowCount() > 0 if self._model is not None else False
         search_has_text = bool(self._search.text())
         enable_enrich = has_selection and self._can_enrich_metadata
-        enrich_hint = self._enrich_disabled_reason or "Configura las APIs para habilitar el enriquecimiento."
+        enrich_hint = (
+            self._enrich_disabled_reason or "Configura las APIs para habilitar el enriquecimiento."
+        )
         enable_spectrum = has_selection and self._can_generate_spectrum
         spectrum_hint = self._spectrum_disabled_reason or "Instala ffmpeg para generar espectros."
 
-=======
-        has_rows = self._model.rowCount() > 0
-        main
         if self._btn_enrich is not None:
             self._btn_enrich.setEnabled(enable_enrich)
-            if enable_enrich:
-                self._btn_enrich.setToolTip("")
-            else:
-                self._btn_enrich.setToolTip(enrich_hint)
+            self._btn_enrich.setToolTip("" if enable_enrich else enrich_hint)
         if self._action_enrich is not None:
             self._action_enrich.setEnabled(enable_enrich)
-            if enable_enrich:
-                self._action_enrich.setStatusTip("Busca metadatos en AcoustID y MusicBrainz.")
-            else:
-                self._action_enrich.setStatusTip(enrich_hint)
+            self._action_enrich.setStatusTip(
+                self._action_enrich_default_tip if enable_enrich else enrich_hint
+            )
 
         if self._btn_spectrum is not None:
             self._btn_spectrum.setEnabled(enable_spectrum)
-            if enable_spectrum:
-                self._btn_spectrum.setToolTip("")
-            else:
-                self._btn_spectrum.setToolTip(spectrum_hint)
+            self._btn_spectrum.setToolTip("" if enable_spectrum else spectrum_hint)
         if self._action_spectrum is not None:
             self._action_spectrum.setEnabled(enable_spectrum)
-            if enable_spectrum:
-                self._action_spectrum.setStatusTip("Genera el espectro de la pista seleccionada.")
-            else:
-                self._action_spectrum.setStatusTip(spectrum_hint)
+            self._action_spectrum.setStatusTip(
+                self._action_spectrum_default_tip if enable_spectrum else spectrum_hint
+            )
 
         if self._action_open_track is not None:
             self._action_open_track.setEnabled(has_selection)
@@ -1590,35 +1467,19 @@ class MainWindow(QMainWindow):
         copy_disabled_tip = "Selecciona al menos una pista para copiar su ruta."
 
         if self._action_open_track is not None:
-            self._action_open_track.setEnabled(has_selection)
-            self._action_open_track.setStatusTip(open_tip if has_selection else "Selecciona una pista para poder abrirla.")
+            self._action_open_track.setStatusTip(
+                open_tip if has_selection else "Selecciona una pista para poder abrirla."
+            )
         if self._action_reveal_track is not None:
-            self._action_reveal_track.setEnabled(has_selection)
-            self._action_reveal_track.setStatusTip(reveal_tip if has_selection else "Selecciona una pista para mostrarla en la carpeta.")
+            self._action_reveal_track.setStatusTip(
+                reveal_tip
+                if has_selection
+                else "Selecciona una pista para mostrarla en la carpeta."
+            )
         if self._action_copy_paths is not None:
-            self._action_copy_paths.setEnabled(has_selection)
             self._action_copy_paths.setStatusTip(
                 self._action_copy_default_tip if has_selection else copy_disabled_tip
             )
-
-        if self._action_enrich is not None:
-            enable_enrich = has_selection and self._can_enrich_metadata
-            self._action_enrich.setEnabled(enable_enrich)
-            if enable_enrich:
-                self._action_enrich.setStatusTip(self._action_enrich_default_tip)
-            else:
-                hint = self._enrich_disabled_reason or "Configura las APIs para habilitar el enriquecimiento."
-                self._action_enrich.setStatusTip(hint)
-        if self._action_spectrum is not None:
-            enable_spectrum = has_selection and self._can_generate_spectrum
-            self._action_spectrum.setEnabled(enable_spectrum)
-            if enable_spectrum:
-                self._action_spectrum.setStatusTip(self._action_spectrum_default_tip)
-            else:
-                hint = self._spectrum_disabled_reason or "Instala ffmpeg para generar espectros."
-                self._action_spectrum.setStatusTip(hint)
-        if self._action_select_all is not None:
-            self._action_select_all.setEnabled(has_rows)
 
     def _resolve_db_path(self, con: sqlite3.Connection | None) -> Path | None:
         if con is None:


### PR DESCRIPTION
## Summary
- consolidate the `_action_*` attribute setup in `MainWindow` so the default tooltip strings from `main` are retained
- drop the duplicate action creation and helper methods left by the conflict and rely on the redesigned action definitions
- rewrite `_update_action_state` to use the preserved default tips while keeping the redesigned enable/tooltip behaviour

## Testing
- ruff format songsearch/ui/main_window.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c925ac5348832ca59ae210d52c87e2