### PR TITLE
Add OpenAI dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "ffmpeg-python==0.2.0",
     "pyacoustid==1.3.0",
     "musicbrainzngs==0.7.1",
+    "openai>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.lock
+++ b/requirements.lock
@@ -6,12 +6,19 @@
 #
 annotated-types==0.7.0
     # via pydantic
+anyio==4.10.0
+    # via
+    #   httpx
+    #   openai
 audioread==3.0.1
     # via pyacoustid
 build==1.3.0
     # via pip-tools
 certifi==2025.8.3
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.4.3
@@ -29,18 +36,31 @@ coverage-badge==1.1.2
     # via songsearch-organizer (pyproject.toml)
 distlib==0.4.0
     # via virtualenv
+distro==1.9.0
+    # via openai
 ffmpeg-python==0.2.0
     # via songsearch-organizer (pyproject.toml)
 filelock==3.19.1
     # via virtualenv
 future==1.0.0
     # via ffmpeg-python
+h11==0.16.0
+    # via httpcore
+httpcore==1.0.9
+    # via httpx
+httpx==0.28.1
+    # via openai
 identify==2.6.14
     # via pre-commit
 idna==3.10
-    # via requests
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 iniconfig==2.1.0
     # via pytest
+jiter==0.11.0
+    # via openai
 markdown-it-py==4.0.0
     # via rich
 mdurl==0.1.2
@@ -55,6 +75,8 @@ mypy-extensions==1.1.0
     # via mypy
 nodeenv==1.9.1
     # via pre-commit
+openai==1.107.3
+    # via songsearch-organizer (pyproject.toml)
 packaging==25.0
     # via
     #   build
@@ -74,7 +96,9 @@ pre-commit==4.3.0
 pyacoustid==1.3.0
     # via songsearch-organizer (pyproject.toml)
 pydantic==2.11.9
-    # via songsearch-organizer (pyproject.toml)
+    # via
+    #   openai
+    #   songsearch-organizer (pyproject.toml)
 pydantic-core==2.33.2
     # via pydantic
 pygments==2.19.2
@@ -120,15 +144,23 @@ shiboken6==6.9.2
     #   pyside6
     #   pyside6-addons
     #   pyside6-essentials
+sniffio==1.3.1
+    # via
+    #   anyio
+    #   openai
 tqdm==4.67.1
-    # via songsearch-organizer (pyproject.toml)
+    # via
+    #   openai
+    #   songsearch-organizer (pyproject.toml)
 typer==0.17.4
     # via songsearch-organizer (pyproject.toml)
 types-pyyaml==6.0.12.20240917
     # via songsearch-organizer (pyproject.toml)
 typing-extensions==4.15.0
     # via
+    #   anyio
     #   mypy
+    #   openai
     #   pydantic
     #   pydantic-core
     #   typer


### PR DESCRIPTION
## Summary
- add the OpenAI client as a runtime dependency in the project metadata
- regenerate the pip-compile lock file to capture the new dependency tree

## Testing
- pip-compile --extra=dev --output-file=requirements.lock pyproject.toml

------
https://chatgpt.com/codex/tasks/task_e_68c94650aa80832c8939a54b76765a53