### PR TITLE
Add AI assistant helpers and cover chat CLI with tests

### DIFF
--- a/songsearch/ai_assistant.py
+++ b/songsearch/ai_assistant.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from typing import Any
+
+DEFAULT_MODEL = "gpt-4o-mini"
+SYSTEM_PROMPT = (
+    "Eres SongSearch Organizer, un asistente experto en bibliotecas musicales. "
+    "Responde en español con instrucciones claras y accionables."
+)
+UI_SYSTEM_PROMPT = (
+    "Actúa como diseñador UX/UI senior para SongSearch Organizer. "
+    "Analiza la descripción y propone mejoras concretas en español."
+)
+MAX_OUTPUT_TOKENS = 500
+TEMPERATURE = 0.3
+
+
+def _ensure_api_key() -> str:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Falta OPENAI_API_KEY; configúralo en tu entorno o en el archivo .env."
+        )
+    return api_key
+
+
+def _resolve_model(override: str | None) -> str:
+    if override:
+        return override
+    env_model = os.getenv("OPENAI_MODEL")
+    if env_model:
+        return env_model
+    return DEFAULT_MODEL
+
+
+def _get_openai_class() -> Any:  # pragma: no cover - small helper
+    from openai import OpenAI  # type: ignore[import-not-found]
+
+    return OpenAI
+
+
+def _create_client() -> Any:
+    api_key = _ensure_api_key()
+    openai_cls = _get_openai_class()
+    return openai_cls(api_key=api_key)
+
+
+def _extract_text(response: Any) -> str:
+    text = getattr(response, "output_text", None)
+    if text:
+        return str(text).strip()
+    output = getattr(response, "output", None)
+    if isinstance(output, list) and output:
+        try:
+            content = output[0]["content"][0]["text"]
+        except (KeyError, IndexError, TypeError):
+            pass
+        else:
+            return str(content).strip()
+    raise RuntimeError("La respuesta del modelo no contiene texto utilizable.")
+
+
+def _format_concerns(concerns: Sequence[str] | None) -> str:
+    if not concerns:
+        return "- Sin incidencias reportadas."
+    return "\n".join(f"- {item}" for item in concerns)
+
+
+def _send_messages(
+    *, system_prompt: str, user_text: str, model: str | None = None
+) -> str:
+    client = _create_client()
+    payload = [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": system_prompt}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": user_text}],
+        },
+    ]
+    response = client.responses.create(
+        model=_resolve_model(model),
+        input=payload,
+        temperature=TEMPERATURE,
+        max_output_tokens=MAX_OUTPUT_TOKENS,
+    )
+    return _extract_text(response)
+
+
+def ask_chat(question: str, *, model: str | None = None) -> str:
+    """Pregunta al asistente general de SongSearch Organizer."""
+    return _send_messages(system_prompt=SYSTEM_PROMPT, user_text=question.strip(), model=model)
+
+
+def suggest_ui_improvements(
+    ui_snapshot: str, *, concerns: Sequence[str] | None = None, model: str | None = None
+) -> str:
+    """Solicita propuestas de mejoras visuales o de UX para la aplicación."""
+    user_text = (
+        "Descripción de la interfaz actual:\n"
+        f"{ui_snapshot.strip()}\n\n"
+        "Problemas o áreas de mejora reportadas:\n"
+        f"{_format_concerns(concerns)}\n\n"
+        "Sugiere mejoras priorizadas y accionables para SongSearch Organizer."
+    )
+    return _send_messages(
+        system_prompt=UI_SYSTEM_PROMPT,
+        user_text=user_text,
+        model=model,
+    )

--- a/songsearch/cli/main.py
+++ b/songsearch/cli/main.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 from rich.logging import RichHandler
 from rich.table import Table
 
+from ..ai_assistant import ask_chat
 from ..core.db import connect, init_db
 from ..core.duplicates import find_duplicates, resolve_move_others
 from ..core.metadata_enricher import enrich_db
@@ -127,6 +128,16 @@ def enrich(
             f"{r.get('mb_confidence', 0):.2f}",
         )
     logger.info(table)
+
+
+@app.command()
+def chat(prompt: str = typer.Argument(..., help="Pregunta para la ayuda inteligente.")) -> None:
+    try:
+        answer = ask_chat(prompt)
+    except RuntimeError as exc:  # pragma: no cover - CLI error path
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo(answer)
 
 
 @app.command()

--- a/tests/test_ai_assistant.py
+++ b/tests/test_ai_assistant.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+
+import songsearch.ai_assistant as ai
+
+
+def test_ask_chat_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        ai.ask_chat("¿Cómo organizo mi biblioteca?")
+
+
+def test_ask_chat_sends_expected_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-song")
+    captured: dict[str, object] = {}
+
+    class DummyResponses:
+        def create(self, **kwargs):
+            captured["payload"] = kwargs
+            return type("Resp", (), {"output_text": "Respuesta generada"})()
+
+    class DummyOpenAI:
+        def __init__(self, *, api_key: str):
+            captured["api_key"] = api_key
+            self.responses = DummyResponses()
+
+    monkeypatch.setattr(ai, "_get_openai_class", lambda: DummyOpenAI)
+
+    answer = ai.ask_chat("¿Cómo escaneo mi biblioteca?")
+
+    assert answer == "Respuesta generada"
+    assert captured["api_key"] == "secret"
+
+    payload = captured["payload"]
+    assert payload["model"] == "gpt-song"
+    assert payload["input"][0]["role"] == "system"
+    assert payload["input"][0]["content"][0]["text"] == ai.SYSTEM_PROMPT
+    assert payload["input"][1]["content"][0]["text"] == "¿Cómo escaneo mi biblioteca?"
+    assert payload["max_output_tokens"] == ai.MAX_OUTPUT_TOKENS
+
+
+def test_suggest_ui_improvements_builds_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-song")
+    captured: dict[str, object] = {}
+
+    class DummyResponses:
+        def create(self, **kwargs):
+            captured["payload"] = kwargs
+            return type("Resp", (), {"output_text": "Añade un panel lateral"})()
+
+    class DummyOpenAI:
+        def __init__(self, *, api_key: str):
+            captured["api_key"] = api_key
+            self.responses = DummyResponses()
+
+    monkeypatch.setattr(ai, "_get_openai_class", lambda: DummyOpenAI)
+
+    suggestion = ai.suggest_ui_improvements(
+        "Cabecera con botones Escanear, Enriquecer y Espectro.",
+        concerns=["Los botones no se distinguen", "Falta feedback visual"],
+    )
+
+    assert suggestion == "Añade un panel lateral"
+
+    payload = captured["payload"]
+    assert payload["model"] == "gpt-song"
+    assert payload["input"][0]["content"][0]["text"] == ai.UI_SYSTEM_PROMPT
+
+    user_text = payload["input"][1]["content"][0]["text"]
+    assert "Cabecera con botones Escanear, Enriquecer y Espectro." in user_text
+    assert "- Los botones no se distinguen" in user_text
+    assert "- Falta feedback visual" in user_text

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import typer
+from typer.testing import CliRunner
+
+from songsearch.cli import main as cli_main
+
+_test_cli = typer.Typer()
+_test_cli.command()(cli_main.chat)
+
+
+def test_chat_command_uses_assistant(monkeypatch):
+    runner = CliRunner()
+    recorded: dict[str, str] = {}
+
+    def fake_ask(prompt: str) -> str:
+        recorded["prompt"] = prompt
+        return "Respuesta asistida"
+
+    monkeypatch.setattr(cli_main, "ask_chat", fake_ask)
+
+    result = runner.invoke(_test_cli, ["¿Qué hace el modo simulate?"])
+
+    assert result.exit_code == 0
+    assert "Respuesta asistida" in result.stdout
+    assert recorded["prompt"] == "¿Qué hace el modo simulate?"


### PR DESCRIPTION
## Summary
- add an AI assistant helper module that wraps OpenAI requests with consistent prompts and validation
- register a `chat` command in the Typer CLI that delegates to the assistant helper and handles failures
- add unit tests that mock OpenAI and the CLI runner to verify request payloads and user-facing output

## Testing
- pytest
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68c94e3c6120832cb7769cbb2925c3b3