### PR TITLE
Update changelog with 0.3.3 and 0.3.4 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Todas las novedades relevantes se documentan en este archivo siguiendo un formato inspirado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/).
 
+## [0.3.4] - 2025-11-03
+### Corregido
+- Plantilla de organización de respaldo en `songsearch/core/organizer.py` para restaurar rutas por defecto sin inconsistencias.
+- Mensajes de advertencia ajustados para reflejar correctamente los fallos de respaldo y sus pasos de mitigación.
+
+## [0.3.3] - 2025-10-31
+### Añadido
+- Módulo `songsearch.ai` con integración del asistente inteligente en la base de código.
+- Comandos `chat` y `assistant` en la CLI para conversaciones guiadas y respuestas contextuales.
+- Dependencia `openai` y configuración inicial del modelo predeterminado para el asistente.
+- Pruebas asociadas que cubren la interacción del módulo de IA y los comandos de la CLI.
+
+### Cambiado
+- Manejo centralizado de credenciales, incluyendo la detección y carga de claves para servicios externos.
+- Advertencias de la aplicación actualizadas para guiar la configuración de claves y el uso seguro del asistente.
+
 ## [0.3.2] - 2025-09-30
 ### Añadido
 - Interfaz principal rediseñada con cabecera estilo macOS, tarjeta de herramientas y distintivo dinámico de resultados.


### PR DESCRIPTION
## Summary
- add the 0.3.3 release notes covering the new AI module, CLI commands and credential handling updates
- document the 0.3.4 hotfix for the backup organizer template and warning messages
- record the publication dates for both releases

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c95f7bdc80832cbbbae9632795a0b4