### PR TITLE
Format assistant command arguments

### DIFF
--- a/songsearch/cli/main.py
+++ b/songsearch/cli/main.py
@@ -176,7 +176,12 @@ def dupes(
 
 
 @app.command()
-def assistant(question: str = typer.Argument(..., help="Pregunta para la ayuda inteligente")) -> None:
+def assistant(
+    question: str = typer.Argument(
+        ...,
+        help="Pregunta para la ayuda inteligente",
+    ),
+) -> None:
     """Consulta la ayuda inteligente basada en ChatGPT."""
 
     from ..ai import assistant as ai_assistant


### PR DESCRIPTION
## Summary
- split the assistant command's argument definition across multiple lines for readability

## Testing
- ruff format songsearch/cli/main.py
- ruff check songsearch/cli/main.py

------
https://chatgpt.com/codex/tasks/task_e_68c964349df8832c8fcbfd5da707b7e7