### PR TITLE
ci: retry release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,12 +15,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
-        uses: googleapis/release-please-action@v4
+        uses: nick-fields/retry@v3
         with:
-          release-type: python
-          # Fichero de configuración
-          config-file: release-please-config.json
-          # Manifest (múltiples paquetes si más adelante lo necesitas)
-          manifest-file: .release-please-manifest.json
-          # Token por defecto
-          token: ${{ secrets.GITHUB_TOKEN }}
+          max_attempts: 3
+          retry_wait_seconds: 30
+          retry_on: error
+          timeout_minutes: 10
+          command: |
+            set -euo pipefail
+
+            run_release_please() {
+              local description="$1"
+              shift
+
+              echo "🔁 Ejecutando ${description}"
+              if ! "$@"; then
+                local exit_code=$?
+                echo "::error::${description} falló con código ${exit_code}." >&2
+                return ${exit_code}
+              fi
+            }
+
+            run_release_please "release-pr" \
+              npx --yes release-please release-pr \
+              --debug \
+              --token="${{ secrets.GITHUB_TOKEN }}" \
+              --repo-url="${{ github.repository }}" \
+              --config-file="release-please-config.json" \
+              --manifest-file=".release-please-manifest.json"
+
+            run_release_please "github-release" \
+              npx --yes release-please github-release \
+              --debug \
+              --token="${{ secrets.GITHUB_TOKEN }}" \
+              --repo-url="${{ github.repository }}" \
+              --config-file="release-please-config.json" \
+              --manifest-file=".release-please-manifest.json"


### PR DESCRIPTION
## Summary
- wrap the release automation in `nick-fields/retry@v3` so it automatically retries up to three times with 30 second spacing
- run the Release Please CLI with the existing manifest/config and debug logging to mirror the previous action behavior while surfacing error causes

## Testing
- not run (GitHub-hosted workflow)


------
https://chatgpt.com/codex/tasks/task_e_68c96cfd0884832c84d00ecf786b47eb