### PR TITLE
Split linting from test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,25 @@ on:
   pull_request:
 
 jobs:
-  lint-and-test:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install project
+        run: python -m pip install .[dev]
+      - name: Ruff (lint & format check)
+        run: |
+          ruff format --check .
+          ruff check .
+      - name: Mypy
+        run: mypy songsearch/core
+  tests:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -22,12 +40,6 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install project
         run: python -m pip install .[dev]
-      - name: Ruff (lint & format check)
-        run: |
-          ruff format --check .
-          ruff check .
-      - name: Mypy
-        run: mypy songsearch/core
       - name: Pytest with coverage
         run: pytest --cov=songsearch --cov-report=xml --cov-report=term
       - name: Upload coverage report


### PR DESCRIPTION
## Summary
- add a dedicated `lint` job that runs Ruff and MyPy on Ubuntu with Python 3.13
- keep the matrix `tests` job focused on installing the project and running pytest before uploading coverage

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68c972e4d238832ca07b14fe4086f403