### PR TITLE
Limit CI tests to Ubuntu

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- restrict the tests job matrix to ubuntu-latest so the workflow only runs on Linux

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c973b37270832ca95b709a1fb904aa