### PR TITLE
Conditionally upload coverage artifact

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Pytest with coverage
         run: pytest --cov=songsearch --cov-report=xml --cov-report=term
       - name: Upload coverage report
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}


### PR DESCRIPTION
## Summary
- run the "Upload coverage report" step only for the ubuntu-latest / Python 3.12 matrix entry to avoid duplicate artifacts

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c973bb2670832cb12af9ae5cd070bf