### PR TITLE
Fix QShortcut import location

### DIFF
--- a/songsearch/ui/main_window.py
+++ b/songsearch/ui/main_window.py
@@ -25,7 +25,15 @@ from PySide6.QtCore import (
     QTimer,
     Signal,
 )
-from PySide6.QtGui import QAction, QCloseEvent, QColor, QGuiApplication, QIcon, QKeySequence
+from PySide6.QtGui import (
+    QAction,
+    QCloseEvent,
+    QColor,
+    QGuiApplication,
+    QIcon,
+    QKeySequence,
+    QShortcut,
+)
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QDialog,
@@ -43,7 +51,6 @@ from PySide6.QtWidgets import (
     QMenuBar,
     QMessageBox,
     QPushButton,
-    QShortcut,
     QSplitter,
     QStatusBar,
     QTableView,


### PR DESCRIPTION
## Summary
- import QShortcut from PySide6.QtGui instead of PySide6.QtWidgets in main window module

## Testing
- python -m songsearch.app *(fails: ImportError: libGL.so.1 missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c976ac6e7c832c8de82564e76acb94