### PR TITLE
Fix QShortcut import location

### DIFF
--- a/songsearch/ui/main_window.py
+++ b/songsearch/ui/main_window.py
@@ -25,7 +25,15 @@ from PySide6.QtCore import (
     QTimer,
     Signal,
 )
-from PySide6.QtGui import QAction, QCloseEvent, QColor, QGuiApplication, QIcon, QKeySequence
+from PySide6.QtGui import (
+    QAction,
+    QCloseEvent,
+    QColor,
+    QGuiApplication,
+    QIcon,
+    QKeySequence,
+    QShortcut,
+)
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QDialog,
@@ -43,7 +51,6 @@ from PySide6.QtWidgets import (
     QMenuBar,
     QMessageBox,
     QPushButton,
-    QShortcut,
     QSplitter,
     QStatusBar,
     QTableView,
@@ -1406,7 +1413,7 @@ class MainWindow(QMainWindow):
         self._action_help_overview = QAction(_load_icon("help.png"), "Centro de ayuda", self)
         self._action_help_overview.setShortcut(QKeySequence(QKeySequence.StandardKey.HelpContents))
         self._action_help_overview.setStatusTip("Descubre atajos, dependencias y consejos de uso.")
-        self._action_help_overview.setMenuRole(QAction.MenuRole.HelpRole)
+        self._action_help_overview.setMenuRole(QAction.MenuRole.ApplicationSpecificRole)
         self._action_help_overview.triggered.connect(self._open_help_center)
 
         self._action_about = QAction("Acerca de SongSearch Organizer", self)


### PR DESCRIPTION
## Summary
- import QShortcut from PySide6.QtGui instead of PySide6.QtWidgets in main window module
- mark the help center action as application-specific so it no longer uses the unavailable HelpRole menu role

## Testing
- QT_QPA_PLATFORM=offscreen python -m songsearch.app *(manually terminated after launch; verifies UI loads without import errors)*
- ruff check songsearch/ui/main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68c976ac6e7c832c8de82564e76acb94