### PR TITLE
Handle missing AIFF support in metadata enrichment

### DIFF
--- a/songsearch/core/metadata_enricher.py
+++ b/songsearch/core/metadata_enricher.py
@@ -116,6 +116,12 @@ def enrich_file(
             }
             if best is None or cand["mb_confidence"] > best["mb_confidence"]:
                 best = cand
+    except ModuleNotFoundError as exc:
+        update_fields(con, str(path), {"fp_status": "skipped"})
+        logger.warning(
+            "AIFF support requires Python <3.13; skipping file %s (%s)", path, exc
+        )
+        return None
     except Exception as e:
         update_fields(con, str(path), {"fp_status": "error"})
         logger.error("enrich error %s: %s", path, e)


### PR DESCRIPTION
## Summary
- add dedicated handling for ModuleNotFoundError during metadata enrichment
- record skipped fingerprint status and log an AIFF support warning when the module import fails

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c97e2951f0832c8dd03b7a6e67a4c4