### PR TITLE
Add help center proxy and UI tests

### DIFF
--- a/songsearch/core/help_center.py
+++ b/songsearch/core/help_center.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""Helpers that expose the intelligent help-center features to the UI layer."""
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .. import ai_assistant as ai
+
+HistoryEntry = Mapping[str, Any]
+
+_ROLE_LABELS = {
+    "user": "Usuario",
+    "assistant": "Asistente",
+    "system": "Sistema",
+}
+
+
+def _clean_text(value: Any) -> str:
+    return str(value).strip()
+
+
+def _filter_history(
+    history: Sequence[HistoryEntry] | None, *, mode: str
+) -> list[HistoryEntry]:
+    if not history:
+        return []
+    selected: list[HistoryEntry] = []
+    for entry in history:
+        try:
+            entry_mode = str(entry.get("mode", ""))
+        except AttributeError:
+            continue
+        if entry_mode == mode:
+            selected.append(entry)
+    return selected
+
+
+def _render_history(entries: Sequence[HistoryEntry], *, mode: str) -> str:
+    lines: list[str] = []
+    for entry in entries:
+        role = str(entry.get("role", "assistant"))
+        content = _clean_text(entry.get("content", ""))
+        if not content:
+            continue
+        label = _ROLE_LABELS.get(role, role.capitalize() or "Mensaje")
+        if role == "assistant" and mode == "ui":
+            label = "Asistente (UI)"
+        lines.append(f"{label}: {content}")
+    return "\n".join(lines)
+
+
+def _build_ui_concerns(entries: Sequence[HistoryEntry]) -> list[str]:
+    concerns: list[str] = []
+    for entry in entries:
+        content = _clean_text(entry.get("content", ""))
+        if not content:
+            continue
+        role = str(entry.get("role", "user"))
+        if role == "assistant":
+            concerns.append(f"Respuesta previa del asistente: {content}")
+        elif role == "system":
+            concerns.append(f"Nota del sistema: {content}")
+        else:
+            concerns.append(content)
+    return concerns
+
+
+def ask_chat(prompt: str, history: Sequence[HistoryEntry] | None = None) -> str:
+    """Proxy that adapts the UI conversation to ``ai_assistant.ask_chat``."""
+
+    clean_prompt = _clean_text(prompt)
+    past_entries = _filter_history(history, mode="chat")
+    context = _render_history(past_entries, mode="chat")
+    if context:
+        message = (
+            "Contexto de la conversación hasta ahora:\n"
+            f"{context}\n\n"
+            "Nueva consulta:\n"
+            f"{clean_prompt}"
+        )
+    else:
+        message = clean_prompt
+    return ai.ask_chat(message)
+
+
+def suggest_ui_improvements(
+    prompt: str, history: Sequence[HistoryEntry] | None = None
+) -> str:
+    """Proxy that adapts the UI suggestion flow to ``ai_assistant`` helpers."""
+
+    clean_prompt = _clean_text(prompt)
+    past_entries = _filter_history(history, mode="ui")
+    context = _render_history(past_entries, mode="ui")
+    concerns = _build_ui_concerns(past_entries) or None
+    if context:
+        snapshot = (
+            "Resumen del intercambio previo sobre la interfaz:\n"
+            f"{context}\n\n"
+            "Detalles adicionales proporcionados por el usuario:\n"
+            f"{clean_prompt}"
+        )
+    else:
+        snapshot = clean_prompt
+    return ai.suggest_ui_improvements(snapshot, concerns=concerns)

--- a/songsearch/ui/main_window.py
+++ b/songsearch/ui/main_window.py
@@ -73,6 +73,12 @@ logger = logging.getLogger(__name__)
 
 _ICON_DIR = Path(__file__).resolve().parents[2] / "assets" / "icons"
 
+_HELP_MODULE_CANDIDATES: tuple[str, ...] = (
+    "songsearch.core.help_center",
+    "songsearch.core.help",
+    "songsearch.core.assistant",
+)
+
 
 def _load_icon(name: str) -> QIcon:
     """Return a ``QIcon`` for *name* if the asset exists."""
@@ -946,14 +952,9 @@ class MainWindow(QMainWindow):
         if cached is not None:
             return cached
 
-        candidates = (
-            "songsearch.core.help_center",
-            "songsearch.core.help",
-            "songsearch.core.assistant",
-        )
         searched_modules: list[str] = []
         last_error: Exception | None = None
-        for module_name in candidates:
+        for module_name in _HELP_MODULE_CANDIDATES:
             try:
                 module = importlib.import_module(module_name)
             except ModuleNotFoundError:

--- a/tests/test_help_center.py
+++ b/tests/test_help_center.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from songsearch.core import help_center
+
+
+def test_help_center_ask_chat_includes_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_ask_chat(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "respuesta generada"
+
+    monkeypatch.setattr(help_center.ai, "ask_chat", fake_ask_chat)
+
+    history = (
+        {"role": "user", "content": "Hola", "mode": "chat"},
+        {
+            "role": "assistant",
+            "content": "Puedes revisar la pestaña Biblioteca para comenzar.",
+            "mode": "chat",
+        },
+        {"role": "user", "content": "La cabecera está muy cargada", "mode": "ui"},
+    )
+
+    answer = help_center.ask_chat("¿Cómo mejoro mi flujo de trabajo?", history=history)
+
+    assert answer == "respuesta generada"
+    prompt = captured["prompt"]
+    assert "Contexto de la conversación" in prompt
+    assert "Usuario: Hola" in prompt
+    assert "Nueva consulta" in prompt
+    assert "¿Cómo mejoro mi flujo de trabajo?" in prompt
+    assert "cabecera" not in prompt  # proviene de un historial de modo distinto
+
+
+def test_help_center_suggest_ui_improvements_builds_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_suggest(snapshot: str, *, concerns: list[str] | None = None) -> str:
+        captured["snapshot"] = snapshot
+        captured["concerns"] = concerns
+        return "ajusta el contraste"
+
+    monkeypatch.setattr(help_center.ai, "suggest_ui_improvements", fake_suggest)
+
+    history = (
+        {"role": "user", "content": "Panel lateral saturado", "mode": "ui"},
+        {
+            "role": "assistant",
+            "content": "Considera un diseño de dos columnas para agrupar filtros.",
+            "mode": "ui",
+        },
+        {"role": "system", "content": "Consulta anterior completada", "mode": "ui"},
+        {"role": "assistant", "content": "¿Necesitas algo más?", "mode": "chat"},
+    )
+
+    suggestion = help_center.suggest_ui_improvements(
+        "Añadir botón de filtros rápidos",
+        history=history,
+    )
+
+    assert suggestion == "ajusta el contraste"
+    snapshot = captured["snapshot"]
+    assert "Resumen del intercambio previo" in snapshot
+    assert "Panel lateral saturado" in snapshot
+    assert "dos columnas" in snapshot
+    assert "Añadir botón de filtros rápidos" in snapshot
+
+    concerns = captured["concerns"]
+    assert concerns is not None
+    assert concerns[0] == "Panel lateral saturado"
+    assert any(item.startswith("Respuesta previa del asistente") for item in concerns)
+    assert any(item.startswith("Nota del sistema") for item in concerns)
+
+
+@pytest.fixture(scope="module")
+def qapp() -> Any:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    try:
+        from PySide6.QtWidgets import QApplication
+    except ImportError as exc:  # pragma: no cover - entorno sin soporte gráfico
+        pytest.skip(f"PySide6 no disponible: {exc}")
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_help_center_dialog_can_be_shown(qapp: Any) -> None:
+    from songsearch.ui.main_window import _HelpCenterDialog
+
+    dialog = _HelpCenterDialog()
+    dialog.set_overview_html("<b>Centro de ayuda</b>")
+    dialog.update_history([])
+    dialog.show_feedback("Listo para ayudarte")
+    dialog.show_feedback("Ups, ocurrió un problema", error=True)
+    dialog.update_history(
+        [
+            {"role": "user", "content": "¿Cómo importo archivos?", "mode": "chat"},
+            {
+                "role": "assistant",
+                "content": "Usa la acción Escanear carpeta en la barra superior.",
+                "mode": "chat",
+            },
+        ]
+    )
+    dialog.set_loading(True)
+    dialog.set_loading(False)
+    dialog.focus_prompt()
+    dialog.show()
+    qapp.processEvents()
+    dialog.close()


### PR DESCRIPTION
## Summary
- provide `songsearch.core.help_center` proxies that adapt chat and UI requests using the existing AI assistant
- update the main window help resolver to prioritise the new help center module
- add coverage that validates the helpers and ensures the help dialog can be constructed safely

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c982629784832cb0061513ed5895e1