### PR TITLE
Fix PySide skip in UI test and apply formatting

### DIFF
--- a/songsearch/core/help_center.py
+++ b/songsearch/core/help_center.py
@@ -20,9 +20,7 @@ def _clean_text(value: Any) -> str:
     return str(value).strip()
 
 
-def _filter_history(
-    history: Sequence[HistoryEntry] | None, *, mode: str
-) -> list[HistoryEntry]:
+def _filter_history(history: Sequence[HistoryEntry] | None, *, mode: str) -> list[HistoryEntry]:
     if not history:
         return []
     selected: list[HistoryEntry] = []
@@ -84,9 +82,7 @@ def ask_chat(prompt: str, history: Sequence[HistoryEntry] | None = None) -> str:
     return ai.ask_chat(message)
 
 
-def suggest_ui_improvements(
-    prompt: str, history: Sequence[HistoryEntry] | None = None
-) -> str:
+def suggest_ui_improvements(prompt: str, history: Sequence[HistoryEntry] | None = None) -> str:
     """Proxy that adapts the UI suggestion flow to ``ai_assistant`` helpers."""
 
     clean_prompt = _clean_text(prompt)

--- a/songsearch/core/metadata_enricher.py
+++ b/songsearch/core/metadata_enricher.py
@@ -141,9 +141,7 @@ def enrich_file(
                 best = cand
     except ModuleNotFoundError as exc:
         update_fields(con, str(path), {"fp_status": "skipped"})
-        logger.warning(
-            "AIFF support requires Python <3.13; skipping file %s (%s)", path, exc
-        )
+        logger.warning("AIFF support requires Python <3.13; skipping file %s (%s)", path, exc)
         return None
     except Exception as e:
         update_fields(con, str(path), {"fp_status": "error"})

--- a/songsearch/ui/main_window.py
+++ b/songsearch/ui/main_window.py
@@ -33,6 +33,7 @@ from PySide6.QtGui import (
     QIcon,
     QKeySequence,
 )
+
 try:  # PySide6 < 6.7 exports ``QShortcut`` from ``QtWidgets``
     from PySide6.QtGui import QShortcut
 except ImportError:  # pragma: no cover - fallback for older runtimes
@@ -1396,12 +1397,8 @@ class MainWindow(QMainWindow):
         self._action_simulate.setStatusTip("Genera un plan de organización sin aplicar cambios.")
         self._action_simulate.triggered.connect(self._simulate_library)
 
-        self._action_apply_plan = QAction(
-            _load_icon("apply.png"), "Mover/ Copiar archivos…", self
-        )
-        self._action_apply_plan.setStatusTip(
-            "Aplica el último plan de organización generado."
-        )
+        self._action_apply_plan = QAction(_load_icon("apply.png"), "Mover/ Copiar archivos…", self)
+        self._action_apply_plan.setStatusTip("Aplica el último plan de organización generado.")
         self._action_apply_plan.triggered.connect(self._apply_organizer_plan)
 
         self._action_open_track = QAction(_load_icon("open.png"), "Abrir", self)
@@ -2170,7 +2167,9 @@ class MainWindow(QMainWindow):
         if self._btn_simulate is not None:
             self._btn_simulate.setEnabled(simulate_available)
             self._btn_simulate.setToolTip(
-                "" if simulate_available else "Conecta una base de datos para simular la biblioteca."
+                ""
+                if simulate_available
+                else "Conecta una base de datos para simular la biblioteca."
             )
         if self._action_simulate is not None:
             self._action_simulate.setEnabled(simulate_available)
@@ -2186,11 +2185,7 @@ class MainWindow(QMainWindow):
             self._btn_apply_plan.setToolTip("" if has_plan else plan_hint)
         if self._action_apply_plan is not None:
             self._action_apply_plan.setEnabled(has_plan)
-            apply_tip = (
-                "Aplica el último plan de organización generado."
-                if has_plan
-                else plan_hint
-            )
+            apply_tip = "Aplica el último plan de organización generado." if has_plan else plan_hint
             self._action_apply_plan.setStatusTip(apply_tip)
 
         if self._btn_enrich is not None:

--- a/tests/test_ui_organizer.py
+++ b/tests/test_ui_organizer.py
@@ -9,6 +9,9 @@ import pytest
 pytest.importorskip(
     "PySide6.QtWidgets",
     reason="PySide6 no está disponible o falta libGL.so.1 en el entorno de ejecución",
+    exc_type=ImportError,
+)
+pytest.importorskip(
     "PySide6.QtGui",
     reason="Qt runtime with libEGL is required for UI tests",
     exc_type=ImportError,
@@ -24,9 +27,7 @@ def qapp():
     try:
         from PySide6.QtWidgets import QApplication
     except ImportError as exc:
-        raise pytest.SkipTest(
-            "Qt runtime with libEGL is required for UI tests"
-        ) from exc
+        raise pytest.SkipTest("Qt runtime with libEGL is required for UI tests") from exc
 
     app = QApplication.instance()
     if app is None:


### PR DESCRIPTION
## Summary
- fix `tests/test_ui_organizer.py` to call `pytest.importorskip` separately for the required PySide6 modules so syntax errors no longer block collection
- run `ruff format` to normalize style in `songsearch/core/help_center.py`, `songsearch/core/metadata_enricher.py`, and `songsearch/ui/main_window.py`

## Testing
- pytest --cov=songsearch --cov-report=xml --cov-report=term
- ruff format --check .

------
https://chatgpt.com/codex/tasks/task_e_68c9d41a2a90832cb87fd3ded3992e1e