### PR TITLE
Fix import ordering for lint compliance

### DIFF
--- a/songsearch/core/help_center.py
+++ b/songsearch/core/help_center.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Helpers that expose the intelligent help-center features to the UI layer."""
+
+from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from typing import Any

--- a/songsearch/core/metadata_enricher.py
+++ b/songsearch/core/metadata_enricher.py
@@ -8,6 +8,18 @@ import warnings
 from pathlib import Path
 from typing import Any
 
+import acoustid
+import musicbrainzngs
+from mutagen import File as MutagenFile
+
+from .db import (
+    get_by_path,
+    get_fingerprint_cache,
+    update_fields,
+    upsert_fingerprint_cache,
+)
+
+
 logger = logging.getLogger(__name__)
 
 with warnings.catch_warnings():
@@ -21,17 +33,6 @@ with warnings.catch_warnings():
         )
     else:
         _AIFC_AVAILABLE = True
-
-import acoustid
-import musicbrainzngs
-from mutagen import File as MutagenFile
-
-from .db import (
-    get_by_path,
-    get_fingerprint_cache,
-    update_fields,
-    upsert_fingerprint_cache,
-)
 
 _AIFF_SUFFIXES = {".aif", ".aiff"}
 


### PR DESCRIPTION
## Summary
- move the help center module docstring ahead of the future import to satisfy Ruff
- regroup metadata enricher imports so they appear at the top of the module while keeping the conditional `aifc` handling

## Testing
- `ruff format --check .`


------
https://chatgpt.com/codex/tasks/task_e_68c9d6c50734832caf78da7a8fafb788